### PR TITLE
[GENAI-325] - Add certain users to a certain group on user signup

### DIFF
--- a/backend/open_webui/models/groups.py
+++ b/backend/open_webui/models/groups.py
@@ -245,5 +245,11 @@ class GroupTable:
                 log.exception(e)
                 return False
 
+    def get_group_by_name(self, name: str) -> Optional[GroupModel]:
+        """Get a group by its name."""
+        with get_db() as db:
+            group = db.query(Group).filter(func.lower(Group.name) == name.lower()).first()
+            return GroupModel.model_validate(group) if group else None
+
 
 Groups = GroupTable()

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -465,18 +465,18 @@ def assign_user_to_domain_group(email: str, user_id: str, target_group_name: str
     try:
         # List of allowed domains
         ALLOWED_DOMAINS = [
-        "attenda.io",
-        "bigspark.dev",
-        "confidios.com",
-        "creode.co.uk",
-        "hibernia-labs.com",
-        "lenvi.com",
-        "manchester.ac.uk",
-        "mennagroup.com",
-        "morganstanley.com",
-        "suresite.co.uk",
-        "whitecapconsulting.co.uk",
-    ]
+            "attenda.io",
+            "bigspark.dev",
+            "confidios.com",
+            "creode.co.uk",
+            "hibernia-labs.com",
+            "lenvi.com",
+            "manchester.ac.uk",
+            "mennagroup.com",
+            "morganstanley.com",
+            "suresite.co.uk",
+            "whitecapconsulting.co.uk",
+        ]
 
         domain = email.split('@')[-1].lower()
 
@@ -484,9 +484,50 @@ def assign_user_to_domain_group(email: str, user_id: str, target_group_name: str
         if domain in [d.lower() for d in ALLOWED_DOMAINS]:
             # Get the target group
             target_group = Groups.get_group_by_name(target_group_name)
+
+            # If group exists, add user to it
             if target_group:
                 if user_id not in target_group.user_ids:
                     target_group.user_ids.append(user_id)
+
+                    # Ensure group has proper permissions
+                    if not target_group.permissions:
+                        target_group.permissions = {
+                            "workspace": {
+                                "models": True,
+                                "knowledge": True,
+                                "prompts": True,
+                                "tools": True
+                            },
+                            "sharing": {
+                                "public_models": False,
+                                "public_knowledge": False,
+                                "public_prompts": False,
+                                "public_tools": False
+                            },
+                            "chat": {
+                                "controls": True,
+                                "file_upload": True,
+                                "delete": True,
+                                "edit": True,
+                                "share": True,
+                                "export": True,
+                                "stt": True,
+                                "tts": True,
+                                "call": True,
+                                "multiple_models": True,
+                                "temporary": True,
+                                "temporary_enforced": False
+                            },
+                            "features": {
+                                "direct_tool_servers": False,
+                                "web_search": True,
+                                "image_generation": True,
+                                "code_interpreter": True,
+                                "notes": True
+                            }
+                        }
+
                     update_form = GroupUpdateForm(
                         name=target_group.name,
                         description=target_group.description,
@@ -546,7 +587,7 @@ async def signup(request: Request, response: Response, form_data: SignupForm):
 
         if user:
             # Assign user to domain group if their email domain matches
-            assign_user_to_domain_group(form_data.email.lower(), user.id, "Domain Users")
+            assign_user_to_domain_group(form_data.email.lower(), user.id, "Manchester Roundtable")
 
             expires_delta = parse_duration(request.app.state.config.JWT_EXPIRES_IN)
             expires_at = None

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -19,7 +19,7 @@ from open_webui.models.auths import (
     UserResponse,
 )
 from open_webui.models.users import Users
-from open_webui.models.groups import Groups
+from open_webui.models.groups import Groups, GroupUpdateForm
 
 from open_webui.constants import ERROR_MESSAGES, WEBHOOK_MESSAGES
 from open_webui.env import (
@@ -460,9 +460,46 @@ async def signin(request: Request, response: Response, form_data: SigninForm):
 ############################
 
 
+def assign_user_to_domain_group(email: str, user_id: str, target_group_name: str):
+    """Assign user to a specific group if their email domain is in the allowed list."""
+    try:
+        # List of allowed domains
+        ALLOWED_DOMAINS = [
+        "attenda.io",
+        "bigspark.dev",
+        "confidios.com",
+        "creode.co.uk",
+        "hibernia-labs.com",
+        "lenvi.com",
+        "manchester.ac.uk",
+        "mennagroup.com",
+        "morganstanley.com",
+        "suresite.co.uk",
+        "whitecapconsulting.co.uk",
+    ]
+
+        domain = email.split('@')[-1].lower()
+
+        # Check if domain is in allowed list
+        if domain in [d.lower() for d in ALLOWED_DOMAINS]:
+            # Get the target group
+            target_group = Groups.get_group_by_name(target_group_name)
+            if target_group:
+                if user_id not in target_group.user_ids:
+                    target_group.user_ids.append(user_id)
+                    update_form = GroupUpdateForm(
+                        name=target_group.name,
+                        description=target_group.description,
+                        permissions=target_group.permissions,
+                        user_ids=target_group.user_ids,
+                    )
+                    Groups.update_group_by_id(id=target_group.id, form_data=update_form)
+                    log.info(f"Added user {user_id} to group {target_group_name} based on domain {domain}")
+    except Exception as e:
+        log.error(f"Error assigning user to domain group: {e}")
+
 @router.post("/signup", response_model=SessionUserResponse)
 async def signup(request: Request, response: Response, form_data: SignupForm):
-
     if WEBUI_AUTH:
         if (
             not request.app.state.config.ENABLE_SIGNUP
@@ -508,6 +545,9 @@ async def signup(request: Request, response: Response, form_data: SignupForm):
         )
 
         if user:
+            # Assign user to domain group if their email domain matches
+            assign_user_to_domain_group(form_data.email.lower(), user.id, "Domain Users")
+
             expires_delta = parse_duration(request.app.state.config.JWT_EXPIRES_IN)
             expires_at = None
             if expires_delta:


### PR DESCRIPTION
Based on allowed domains:
"attenda.io",
   "bigspark.dev", 
   "confidios.com",
   "creode.co.uk",
   "hibernia-labs.com",
   "lenvi.com",
   "manchester.ac.uk",
   "mennagroup.com",
   "morganstanley.com",
   "suresite.co.uk",
   "whitecapconsulting.co.uk"

any user email that passes the condition will be added to "Manchester Roundtable" group. The group name is hardcoded for demo purposes.