### PR TITLE
fix/TRAU-419

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,10 +1,13 @@
+# Maximum seconds to wait between stream chunks before aborting (default: 60, minimum recommended: 30)
+AIOHTTP_CLIENT_TIMEOUT_SOCK_READ=60
+
 LANGFUSE_SK=""
 LANGFUSE_PK=""
 LANGFUSE_HOST=""
 
 BILLING_ENABLED=true
-STRIPE_SECRET_KEY=sk_test_2222
-STRIPE_WEBHOOK_SECRET=whsec_sddasdsa
+STRIPE_SECRET_KEY=""
+STRIPE_WEBHOOK_SECRET=""
 STRIPE_PRICE_ID=price_dassad
 STRIPE_FREE_TIER_CENTS=500
 WEBUI_URL=http://localhost:5173

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -10,3 +10,15 @@ Pipfile
 /data/*
 /open_webui/data/*
 .webui_secret_key
+
+# Runtime-generated static files (copied from frontend build or downloaded on startup)
+/open_webui/static/favicon.png
+/open_webui/static/favicon-dark.png
+/open_webui/static/logo.png
+/open_webui/static/splash.png
+/open_webui/static/splash-dark.png
+/open_webui/static/loader.js
+/open_webui/static/custom.css
+/open_webui/static/site.webmanifest
+/open_webui/static/user.png
+/open_webui/static/user-import.csv

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -719,6 +719,29 @@ else:
         AIOHTTP_CLIENT_TIMEOUT_MODEL_LIST = 10
 
 
+_sock_read_env = os.environ.get("AIOHTTP_CLIENT_TIMEOUT_SOCK_READ")
+_sock_read_source = "configured" if _sock_read_env is not None else "default"
+AIOHTTP_CLIENT_TIMEOUT_SOCK_READ = _sock_read_env if _sock_read_env is not None else "60"
+
+if AIOHTTP_CLIENT_TIMEOUT_SOCK_READ == "":
+    AIOHTTP_CLIENT_TIMEOUT_SOCK_READ = None
+else:
+    try:
+        AIOHTTP_CLIENT_TIMEOUT_SOCK_READ = int(AIOHTTP_CLIENT_TIMEOUT_SOCK_READ)
+    except ValueError:
+        log.warning(
+            f"[aiohttp] Invalid AIOHTTP_CLIENT_TIMEOUT_SOCK_READ value "
+            f"'{AIOHTTP_CLIENT_TIMEOUT_SOCK_READ}', falling back to 60s."
+        )
+        AIOHTTP_CLIENT_TIMEOUT_SOCK_READ = 60
+
+# SSE keepalive interval derived from sock_read: sock_read/4, capped at 20s
+# Must stay under 30s (Google Cloud frontend proxy idle stream timeout)
+_sse_keepalive_base = AIOHTTP_CLIENT_TIMEOUT_SOCK_READ if AIOHTTP_CLIENT_TIMEOUT_SOCK_READ is not None else 60
+SSE_KEEPALIVE_INTERVAL = min(_sse_keepalive_base // 4, 20)
+_sse_keepalive_source = "derived" if _sock_read_source == "default" else f"derived from AIOHTTP_CLIENT_TIMEOUT_SOCK_READ={AIOHTTP_CLIENT_TIMEOUT_SOCK_READ}s"
+
+
 AIOHTTP_CLIENT_TIMEOUT_TOOL_SERVER_DATA = os.environ.get(
     "AIOHTTP_CLIENT_TIMEOUT_TOOL_SERVER_DATA", "10"
 )

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -720,26 +720,38 @@ else:
 
 
 _sock_read_env = os.environ.get("AIOHTTP_CLIENT_TIMEOUT_SOCK_READ")
-_sock_read_source = "configured" if _sock_read_env is not None else "default"
-AIOHTTP_CLIENT_TIMEOUT_SOCK_READ = _sock_read_env if _sock_read_env is not None else "60"
 
-if AIOHTTP_CLIENT_TIMEOUT_SOCK_READ == "":
+if _sock_read_env is None:
+    _sock_read_source = "default"
+    AIOHTTP_CLIENT_TIMEOUT_SOCK_READ = 60
+elif _sock_read_env == "":
+    _sock_read_source = "disabled"
     AIOHTTP_CLIENT_TIMEOUT_SOCK_READ = None
 else:
     try:
-        AIOHTTP_CLIENT_TIMEOUT_SOCK_READ = int(AIOHTTP_CLIENT_TIMEOUT_SOCK_READ)
+        _parsed = int(_sock_read_env)
+        if _parsed < 1:
+            raise ValueError("must be a positive integer")
+        _sock_read_source = "configured"
+        AIOHTTP_CLIENT_TIMEOUT_SOCK_READ = _parsed
     except ValueError:
         log.warning(
             f"[aiohttp] Invalid AIOHTTP_CLIENT_TIMEOUT_SOCK_READ value "
-            f"'{AIOHTTP_CLIENT_TIMEOUT_SOCK_READ}', falling back to 60s."
+            f"'{_sock_read_env}', falling back to 60s."
         )
+        _sock_read_source = "default"
         AIOHTTP_CLIENT_TIMEOUT_SOCK_READ = 60
 
-# SSE keepalive interval derived from sock_read: sock_read/4, capped at 20s
-# Must stay under 30s (Google Cloud frontend proxy idle stream timeout)
+# SSE keepalive interval derived from sock_read: sock_read/4, capped at 20s.
+# None (keepalives disabled) when sock_read < 4 — interval would be 0 and busy-loop.
 _sse_keepalive_base = AIOHTTP_CLIENT_TIMEOUT_SOCK_READ if AIOHTTP_CLIENT_TIMEOUT_SOCK_READ is not None else 60
-SSE_KEEPALIVE_INTERVAL = min(_sse_keepalive_base // 4, 20)
-_sse_keepalive_source = "derived" if _sock_read_source == "default" else f"derived from AIOHTTP_CLIENT_TIMEOUT_SOCK_READ={AIOHTTP_CLIENT_TIMEOUT_SOCK_READ}s"
+_sse_keepalive_raw = _sse_keepalive_base // 4
+SSE_KEEPALIVE_INTERVAL = min(_sse_keepalive_raw, 20) if _sse_keepalive_raw >= 1 else None
+_sse_keepalive_source = (
+    "derived from default 60s"
+    if _sock_read_source in ("default", "disabled")
+    else f"derived from AIOHTTP_CLIENT_TIMEOUT_SOCK_READ={AIOHTTP_CLIENT_TIMEOUT_SOCK_READ}s"
+)
 
 
 AIOHTTP_CLIENT_TIMEOUT_TOOL_SERVER_DATA = os.environ.get(

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -488,6 +488,10 @@ from open_webui.env import (
     ENABLE_OTEL,
     EXTERNAL_PWA_MANIFEST_URL,
     AIOHTTP_CLIENT_SESSION_SSL,
+    AIOHTTP_CLIENT_TIMEOUT_SOCK_READ,
+    _sock_read_source,
+    SSE_KEEPALIVE_INTERVAL,
+    _sse_keepalive_source,
     ENABLE_STAR_SESSIONS_MIDDLEWARE,
     ENABLE_PUBLIC_ACTIVE_USERS_COUNT,
     # Admin Account Runtime Creation
@@ -591,6 +595,15 @@ https://github.com/open-webui/open-webui
 async def lifespan(app: FastAPI):
     app.state.instance_id = INSTANCE_ID
     start_logger()
+
+    log.info(
+        f"[aiohttp] Stream idle timeout (sock_read): {AIOHTTP_CLIENT_TIMEOUT_SOCK_READ}s ({_sock_read_source}). "
+        f"Override via AIOHTTP_CLIENT_TIMEOUT_SOCK_READ env var (minimum recommended: 30s)."
+    )
+    log.info(
+        f"[sse] Keepalive interval: {SSE_KEEPALIVE_INTERVAL}s ({_sse_keepalive_source}). "
+        f"Derived as min(sock_read/4, 20s) to stay under Google Cloud proxy 30s idle timeout."
+    )
 
     if RESET_CONFIG_ON_START:
         reset_config()

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -66,6 +66,7 @@ from open_webui.env import (
     AIOHTTP_CLIENT_SESSION_SSL,
     AIOHTTP_CLIENT_TIMEOUT,
     AIOHTTP_CLIENT_TIMEOUT_MODEL_LIST,
+    AIOHTTP_CLIENT_TIMEOUT_SOCK_READ,
     BYPASS_MODEL_ACCESS_CONTROL,
 )
 from open_webui.constants import ERROR_MESSAGES
@@ -127,7 +128,10 @@ async def send_post_request(
     r = None
     try:
         session = aiohttp.ClientSession(
-            trust_env=True, timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT)
+            trust_env=True,
+            timeout=aiohttp.ClientTimeout(
+                total=AIOHTTP_CLIENT_TIMEOUT, sock_read=AIOHTTP_CLIENT_TIMEOUT_SOCK_READ
+            ),
         )
 
         headers = {

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -32,6 +32,7 @@ from open_webui.env import (
     AIOHTTP_CLIENT_SESSION_SSL,
     AIOHTTP_CLIENT_TIMEOUT,
     AIOHTTP_CLIENT_TIMEOUT_MODEL_LIST,
+    AIOHTTP_CLIENT_TIMEOUT_SOCK_READ,
     ENABLE_FORWARD_USER_INFO_HEADERS,
     BYPASS_MODEL_ACCESS_CONTROL,
 )
@@ -937,7 +938,10 @@ async def generate_chat_completion(
 
     try:
         session = aiohttp.ClientSession(
-            trust_env=True, timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT)
+            trust_env=True,
+            timeout=aiohttp.ClientTimeout(
+                total=AIOHTTP_CLIENT_TIMEOUT, sock_read=AIOHTTP_CLIENT_TIMEOUT_SOCK_READ
+            ),
         )
 
         r = await session.request(
@@ -1023,7 +1027,12 @@ async def embeddings(request: Request, form_data: dict, user):
         request, url, key, api_config, user=user
     )
     try:
-        session = aiohttp.ClientSession(trust_env=True)
+        session = aiohttp.ClientSession(
+            trust_env=True,
+            timeout=aiohttp.ClientTimeout(
+                total=AIOHTTP_CLIENT_TIMEOUT, sock_read=AIOHTTP_CLIENT_TIMEOUT_SOCK_READ
+            ),
+        )
         r = await session.request(
             method="POST",
             url=f"{url}/embeddings",
@@ -1113,7 +1122,12 @@ async def proxy(path: str, request: Request, user=Depends(get_verified_user)):
         else:
             request_url = f"{url}/{path}"
 
-        session = aiohttp.ClientSession(trust_env=True)
+        session = aiohttp.ClientSession(
+            trust_env=True,
+            timeout=aiohttp.ClientTimeout(
+                total=AIOHTTP_CLIENT_TIMEOUT, sock_read=AIOHTTP_CLIENT_TIMEOUT_SOCK_READ
+            ),
+        )
         r = await session.request(
             method=request.method,
             url=request_url,

--- a/backend/open_webui/routers/pipelines.py
+++ b/backend/open_webui/routers/pipelines.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel
 from starlette.responses import FileResponse
 from typing import Optional
 
-from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL
+from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL, AIOHTTP_CLIENT_TIMEOUT_SOCK_READ
 from open_webui.config import CACHE_DIR
 from open_webui.constants import ERROR_MESSAGES
 
@@ -65,7 +65,10 @@ async def process_pipeline_inlet_filter(request, payload, user, models):
     if "pipeline" in model:
         sorted_filters.append(model)
 
-    async with aiohttp.ClientSession(trust_env=True) as session:
+    async with aiohttp.ClientSession(
+        trust_env=True,
+        timeout=aiohttp.ClientTimeout(sock_read=AIOHTTP_CLIENT_TIMEOUT_SOCK_READ),
+    ) as session:
         for filter in sorted_filters:
             urlIdx = filter.get("urlIdx")
 
@@ -118,7 +121,10 @@ async def process_pipeline_outlet_filter(request, payload, user, models):
     if "pipeline" in model:
         sorted_filters = [model] + sorted_filters
 
-    async with aiohttp.ClientSession(trust_env=True) as session:
+    async with aiohttp.ClientSession(
+        trust_env=True,
+        timeout=aiohttp.ClientTimeout(sock_read=AIOHTTP_CLIENT_TIMEOUT_SOCK_READ),
+    ) as session:
         for filter in sorted_filters:
             urlIdx = filter.get("urlIdx")
 

--- a/backend/open_webui/test/test_streaming_config.py
+++ b/backend/open_webui/test/test_streaming_config.py
@@ -1,0 +1,168 @@
+"""
+Tests for streaming timeout configuration (AIOHTTP_CLIENT_TIMEOUT_SOCK_READ),
+SSE keepalive interval derivation (SSE_KEEPALIVE_INTERVAL), and the
+_keepalive_iter async generator.
+"""
+
+import asyncio
+import importlib
+import sys
+import pytest
+
+
+_KEEPALIVE = object()
+
+
+async def _keepalive_iter(gen, interval):
+    it = gen.__aiter__()
+    pending = asyncio.create_task(it.__anext__())
+    try:
+        while True:
+            done, _ = await asyncio.wait({pending}, timeout=interval)
+            if done:
+                try:
+                    yield pending.result()
+                except StopAsyncIteration:
+                    break
+                pending = asyncio.create_task(it.__anext__())
+            else:
+                yield _KEEPALIVE
+    finally:
+        pending.cancel()
+
+
+def _reload_env(monkeypatch, env_vars: dict):
+    """
+    Apply env_vars, reload open_webui.env, return the reloaded module.
+    Cleans up by restoring the original module after each test.
+    """
+    for key, value in env_vars.items():
+        if value is None:
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, value)
+
+    # Force reload so module-level code re-runs with new env
+    if "open_webui.env" in sys.modules:
+        del sys.modules["open_webui.env"]
+
+    import open_webui.env as env_module
+    return env_module
+
+
+# ---------- AIOHTTP_CLIENT_TIMEOUT_SOCK_READ ----------
+
+class TestSockReadTimeout:
+
+    def test_default_is_60(self, monkeypatch):
+        env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": None})
+        assert env.AIOHTTP_CLIENT_TIMEOUT_SOCK_READ == 60
+
+    def test_default_source_is_default(self, monkeypatch):
+        env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": None})
+        assert env._sock_read_source == "default"
+
+    def test_valid_int_is_parsed(self, monkeypatch):
+        env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": "120"})
+        assert env.AIOHTTP_CLIENT_TIMEOUT_SOCK_READ == 120
+
+    def test_configured_source_when_env_set(self, monkeypatch):
+        env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": "120"})
+        assert env._sock_read_source == "configured"
+
+    def test_empty_string_becomes_none(self, monkeypatch):
+        env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": ""})
+        assert env.AIOHTTP_CLIENT_TIMEOUT_SOCK_READ is None
+
+    def test_garbage_value_falls_back_to_60(self, monkeypatch):
+        env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": "notanumber"})
+        assert env.AIOHTTP_CLIENT_TIMEOUT_SOCK_READ == 60
+
+    def test_float_string_falls_back_to_60(self, monkeypatch):
+        # int() does not accept "60.5"
+        env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": "60.5"})
+        assert env.AIOHTTP_CLIENT_TIMEOUT_SOCK_READ == 60
+
+    def test_zero_is_parsed_as_zero(self, monkeypatch):
+        env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": "0"})
+        assert env.AIOHTTP_CLIENT_TIMEOUT_SOCK_READ == 0
+
+    def test_large_value(self, monkeypatch):
+        env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": "300"})
+        assert env.AIOHTTP_CLIENT_TIMEOUT_SOCK_READ == 300
+
+
+# ---------- SSE_KEEPALIVE_INTERVAL ----------
+
+class TestSseKeepaliveInterval:
+
+    def test_default_sock_read_gives_15s_keepalive(self, monkeypatch):
+        # sock_read=60 → min(60/4, 20) = min(15, 20) = 15
+        env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": None})
+        assert env.SSE_KEEPALIVE_INTERVAL == 15
+
+    def test_120s_sock_read_gives_20s_keepalive(self, monkeypatch):
+        # sock_read=120 → min(120/4, 20) = min(30, 20) = 20
+        env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": "120"})
+        assert env.SSE_KEEPALIVE_INTERVAL == 20
+
+    def test_300s_sock_read_capped_at_20s(self, monkeypatch):
+        # sock_read=300 → min(300/4, 20) = min(75, 20) = 20
+        env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": "300"})
+        assert env.SSE_KEEPALIVE_INTERVAL == 20
+
+    def test_30s_sock_read_gives_7s_keepalive(self, monkeypatch):
+        # sock_read=30 → min(30/4, 20) = min(7, 20) = 7
+        env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": "30"})
+        assert env.SSE_KEEPALIVE_INTERVAL == 7
+
+    def test_keepalive_always_under_30s_proxy_timeout(self, monkeypatch):
+        # For any sock_read >= 1, keepalive must be < 30s (Google proxy timeout)
+        for sock_read in [1, 10, 30, 60, 120, 300, 900]:
+            env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": str(sock_read)})
+            assert env.SSE_KEEPALIVE_INTERVAL < 30, (
+                f"keepalive={env.SSE_KEEPALIVE_INTERVAL}s >= 30s for sock_read={sock_read}s"
+            )
+
+    def test_none_sock_read_uses_60_as_base(self, monkeypatch):
+        # When sock_read is disabled (empty string → None), keepalive still derives from 60
+        env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": ""})
+        assert env.SSE_KEEPALIVE_INTERVAL == 15
+
+
+# ---------- _keepalive_iter ----------
+
+class TestKeepaliveIter:
+
+    async def _collect(self, gen):
+        results = []
+        async for item in gen:
+            results.append(item)
+        return results
+
+    def test_yields_chunks_without_keepalive(self):
+        async def fast_gen():
+            for chunk in ["a", "b", "c"]:
+                yield chunk
+
+        results = asyncio.run(self._collect(_keepalive_iter(fast_gen(), interval=10)))
+        assert results == ["a", "b", "c"]
+
+    def test_injects_keepalive_on_stall(self):
+        async def slow_gen():
+            yield "first"
+            await asyncio.sleep(0.2)
+            yield "second"
+
+        results = asyncio.run(self._collect(_keepalive_iter(slow_gen(), interval=0.05)))
+        assert results[0] == "first"
+        assert _KEEPALIVE in results
+        assert results[-1] == "second"
+
+    def test_terminates_cleanly_on_empty_generator(self):
+        async def empty_gen():
+            return
+            yield  # make it an async generator
+
+        results = asyncio.run(self._collect(_keepalive_iter(empty_gen(), interval=10)))
+        assert results == []

--- a/backend/open_webui/test/test_streaming_config.py
+++ b/backend/open_webui/test/test_streaming_config.py
@@ -5,36 +5,17 @@ _keepalive_iter async generator.
 """
 
 import asyncio
-import importlib
 import sys
 import pytest
 
-
-_KEEPALIVE = object()
-
-
-async def _keepalive_iter(gen, interval):
-    it = gen.__aiter__()
-    pending = asyncio.create_task(it.__anext__())
-    try:
-        while True:
-            done, _ = await asyncio.wait({pending}, timeout=interval)
-            if done:
-                try:
-                    yield pending.result()
-                except StopAsyncIteration:
-                    break
-                pending = asyncio.create_task(it.__anext__())
-            else:
-                yield _KEEPALIVE
-    finally:
-        pending.cancel()
+from open_webui.utils.sse import _KEEPALIVE, _keepalive_iter
 
 
 def _reload_env(monkeypatch, env_vars: dict):
     """
-    Apply env_vars, reload open_webui.env, return the reloaded module.
-    Cleans up by restoring the original module after each test.
+    Apply env_vars, force-reload open_webui.env, return the reloaded module.
+    monkeypatch restores env vars after each test; the module stays evicted
+    from sys.modules and is re-imported fresh on the next _reload_env call.
     """
     for key, value in env_vars.items():
         if value is None:
@@ -74,6 +55,10 @@ class TestSockReadTimeout:
         env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": ""})
         assert env.AIOHTTP_CLIENT_TIMEOUT_SOCK_READ is None
 
+    def test_empty_string_source_is_disabled(self, monkeypatch):
+        env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": ""})
+        assert env._sock_read_source == "disabled"
+
     def test_garbage_value_falls_back_to_60(self, monkeypatch):
         env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": "notanumber"})
         assert env.AIOHTTP_CLIENT_TIMEOUT_SOCK_READ == 60
@@ -83,9 +68,13 @@ class TestSockReadTimeout:
         env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": "60.5"})
         assert env.AIOHTTP_CLIENT_TIMEOUT_SOCK_READ == 60
 
-    def test_zero_is_parsed_as_zero(self, monkeypatch):
+    def test_zero_falls_back_to_60(self, monkeypatch):
         env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": "0"})
-        assert env.AIOHTTP_CLIENT_TIMEOUT_SOCK_READ == 0
+        assert env.AIOHTTP_CLIENT_TIMEOUT_SOCK_READ == 60
+
+    def test_negative_falls_back_to_60(self, monkeypatch):
+        env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": "-5"})
+        assert env.AIOHTTP_CLIENT_TIMEOUT_SOCK_READ == 60
 
     def test_large_value(self, monkeypatch):
         env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": "300"})
@@ -116,12 +105,21 @@ class TestSseKeepaliveInterval:
         env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": "30"})
         assert env.SSE_KEEPALIVE_INTERVAL == 7
 
-    def test_keepalive_always_under_30s_proxy_timeout(self, monkeypatch):
-        # For any sock_read >= 1, keepalive must be < 30s (Google proxy timeout)
-        for sock_read in [1, 10, 30, 60, 120, 300, 900]:
+    def test_keepalive_always_under_20s_when_set(self, monkeypatch):
+        # When set, SSE_KEEPALIVE_INTERVAL must be positive and <= 20
+        for sock_read in [4, 10, 30, 60, 120, 300, 900]:
             env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": str(sock_read)})
-            assert env.SSE_KEEPALIVE_INTERVAL < 30, (
-                f"keepalive={env.SSE_KEEPALIVE_INTERVAL}s >= 30s for sock_read={sock_read}s"
+            assert env.SSE_KEEPALIVE_INTERVAL is not None
+            assert 1 <= env.SSE_KEEPALIVE_INTERVAL <= 20, (
+                f"keepalive={env.SSE_KEEPALIVE_INTERVAL} out of range for sock_read={sock_read}"
+            )
+
+    def test_small_sock_read_disables_keepalive(self, monkeypatch):
+        # sock_read 1-3 are valid positive ints but sock_read//4 == 0, so keepalives disabled
+        for sock_read in [1, 2, 3]:
+            env = _reload_env(monkeypatch, {"AIOHTTP_CLIENT_TIMEOUT_SOCK_READ": str(sock_read)})
+            assert env.SSE_KEEPALIVE_INTERVAL is None, (
+                f"expected None for sock_read={sock_read}, got {env.SSE_KEEPALIVE_INTERVAL}"
             )
 
     def test_none_sock_read_uses_60_as_base(self, monkeypatch):

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -134,25 +134,7 @@ logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
 log = logging.getLogger(__name__)
 
 
-_KEEPALIVE = object()
-
-
-async def _keepalive_iter(gen, interval: float):
-    it = gen.__aiter__()
-    pending = asyncio.create_task(it.__anext__())
-    try:
-        while True:
-            done, _ = await asyncio.wait({pending}, timeout=interval)
-            if done:
-                try:
-                    yield pending.result()
-                except StopAsyncIteration:
-                    break
-                pending = asyncio.create_task(it.__anext__())
-            else:
-                yield _KEEPALIVE
-    finally:
-        pending.cancel()
+from open_webui.utils.sse import _KEEPALIVE, _keepalive_iter
 
 
 DEFAULT_REASONING_TAGS = [
@@ -3231,22 +3213,24 @@ async def process_chat_response(
                 try:
                     await stream_body_handler(response, form_data)
                 except asyncio.TimeoutError:
+                    _timeout_error = (
+                        "Stream timed out — the model stopped responding. "
+                        "Please try again."
+                    )
                     log.warning(
                         f"[stream] Upstream idle timeout (sock_read) after "
                         f"{AIOHTTP_CLIENT_TIMEOUT_SOCK_READ}s with no chunks: "
                         f"chat_id={metadata.get('chat_id')} model={model_id}"
                     )
+                    Chats.upsert_message_to_chat_by_id_and_message_id(
+                        metadata["chat_id"],
+                        metadata["message_id"],
+                        {"error": {"content": _timeout_error}},
+                    )
                     await event_emitter(
                         {
                             "type": "chat:message:error",
-                            "data": {
-                                "error": {
-                                    "content": (
-                                        "Stream timed out — the model stopped responding. "
-                                        "Please try again."
-                                    )
-                                }
-                            },
+                            "data": {"error": {"content": _timeout_error}},
                         }
                     )
 
@@ -3743,7 +3727,12 @@ async def process_chat_response(
                 if event:
                     yield wrap_item(json.dumps(event))
 
-            async for data in _keepalive_iter(original_generator, SSE_KEEPALIVE_INTERVAL):
+            _source = (
+                _keepalive_iter(original_generator, SSE_KEEPALIVE_INTERVAL)
+                if SSE_KEEPALIVE_INTERVAL is not None
+                else original_generator
+            )
+            async for data in _source:
                 if data is _KEEPALIVE:
                     yield ": keepalive\n\n"
                     continue

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -117,6 +117,8 @@ from open_webui.config import (
 )
 from open_webui.env import (
     GLOBAL_LOG_LEVEL,
+    AIOHTTP_CLIENT_TIMEOUT_SOCK_READ,
+    SSE_KEEPALIVE_INTERVAL,
     ENABLE_CHAT_RESPONSE_BASE64_IMAGE_URL_CONVERSION,
     CHAT_RESPONSE_STREAM_DELTA_CHUNK_SIZE,
     CHAT_RESPONSE_MAX_TOOL_CALL_RETRIES,
@@ -130,6 +132,27 @@ from open_webui.constants import TASKS
 
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
 log = logging.getLogger(__name__)
+
+
+_KEEPALIVE = object()
+
+
+async def _keepalive_iter(gen, interval: float):
+    it = gen.__aiter__()
+    pending = asyncio.create_task(it.__anext__())
+    try:
+        while True:
+            done, _ = await asyncio.wait({pending}, timeout=interval)
+            if done:
+                try:
+                    yield pending.result()
+                except StopAsyncIteration:
+                    break
+                pending = asyncio.create_task(it.__anext__())
+            else:
+                yield _KEEPALIVE
+    finally:
+        pending.cancel()
 
 
 DEFAULT_REASONING_TAGS = [
@@ -2861,6 +2884,12 @@ async def process_chat_response(
                                     if not choices:
                                         error = data.get("error", {})
                                         if error:
+                                            log.warning(
+                                                f"[stream] Upstream error in SSE body: "
+                                                f"chat_id={metadata.get('chat_id')} "
+                                                f"model={model_id} "
+                                                f"error={error}"
+                                            )
                                             await event_emitter(
                                                 {
                                                     "type": "chat:completion",
@@ -3199,7 +3228,27 @@ async def process_chat_response(
                     if response.background:
                         await response.background()
 
-                await stream_body_handler(response, form_data)
+                try:
+                    await stream_body_handler(response, form_data)
+                except asyncio.TimeoutError:
+                    log.warning(
+                        f"[stream] Upstream idle timeout (sock_read) after "
+                        f"{AIOHTTP_CLIENT_TIMEOUT_SOCK_READ}s with no chunks: "
+                        f"chat_id={metadata.get('chat_id')} model={model_id}"
+                    )
+                    await event_emitter(
+                        {
+                            "type": "chat:message:error",
+                            "data": {
+                                "error": {
+                                    "content": (
+                                        "Stream timed out — the model stopped responding. "
+                                        "Please try again."
+                                    )
+                                }
+                            },
+                        }
+                    )
 
                 tool_call_retries = 0
                 tool_call_sources = []  # Track citation sources from tool results
@@ -3694,7 +3743,11 @@ async def process_chat_response(
                 if event:
                     yield wrap_item(json.dumps(event))
 
-            async for data in original_generator:
+            async for data in _keepalive_iter(original_generator, SSE_KEEPALIVE_INTERVAL):
+                if data is _KEEPALIVE:
+                    yield ": keepalive\n\n"
+                    continue
+
                 data, _ = await process_filter_functions(
                     request=request,
                     filter_functions=filter_functions,

--- a/backend/open_webui/utils/sse.py
+++ b/backend/open_webui/utils/sse.py
@@ -1,0 +1,31 @@
+import asyncio
+
+# Sentinel yielded by _keepalive_iter when the upstream generator stalls.
+# Callers must check `data is _KEEPALIVE` — do not compare by value.
+_KEEPALIVE = object()
+
+
+async def _keepalive_iter(gen, interval: float):
+    """
+    Wraps an async generator, yielding _KEEPALIVE whenever `interval` seconds
+    pass without a chunk. Callers translate _KEEPALIVE into an SSE comment
+    (': keepalive\\n\\n') to keep proxies from dropping idle connections.
+
+    Uses asyncio.wait instead of asyncio.wait_for so the underlying task is
+    not cancelled on timeout — the generator resumes normally after each ping.
+    """
+    it = gen.__aiter__()
+    pending = asyncio.create_task(it.__anext__())
+    try:
+        while True:
+            done, _ = await asyncio.wait({pending}, timeout=interval)
+            if done:
+                try:
+                    yield pending.result()
+                except StopAsyncIteration:
+                    break
+                pending = asyncio.create_task(it.__anext__())
+            else:
+                yield _KEEPALIVE
+    finally:
+        pending.cancel()


### PR DESCRIPTION
Closes: [TRAU-419](https://keepersolutions.atlassian.net/browse/TRAU-419)

### Changes
- Add AIOHTTP_CLIENT_TIMEOUT_SOCK_READ value instead of None, update session contructors, add generated static files to gitignore
- Update env expample
- Move env loger to main py
- Add derived sse keep alive source from aiohttp_client_timeout_sock_read, add error logs for socket.io
- Add sock_read, keep alive tests

### Summary
When user sends a message, backend opens an aiohttp connection to the upstream model API (OpenAI/Anthropic/...)
The model streams tokens back as SSE chunks and gor slow or large responses, the model sometimes pauses between chunks (thinking, tool calls or long reasoning). If that pause exceeds 30s, the Google Cloud HTTP Load Balancer in front of Cloud Run drops the connection because it sees an idle HTTP stream and terminates it. Backend gets a silent disconnect, the frontend sees the stream stop without error messages in toasts.

So `AIOHTTP_CLIENT_TIMEOUT_SOCK_READ=60` addresses the backend→upstream direction: if the upstream model stops sending for 60s, aiohttp kills that connection and raises `asyncio.TimeoutError` instead of hanging forever.

The keepalive (`SSE_KEEPALIVE_INTERVAL`) in stream_wrapper addresses the backend→browser direction: if the upstream is slow to send chunks, the backend can inject `": keepalive\n\n"` (a convention string) comments into the HTTP response to the browser, so the Google proxy sees traffic and doesn't drop that connection.


`SSE_KEEPALIVE_INTERVAL` can be a stand-alone env variable, but I believe that tying it to `AIOHTTP_CLIENT_TIMEOUT_SOCK_READ` is good approach too because we want keep_alive interval to be less that sock_read in every scenario and, according to google cloud run support and the info that default timeout is 30 seconds, our derived max would be 20 seconds. The logic was `min(sock_read // 4, 20)`.

