### PR TITLE
TRAU-466:  Add user toggle for PII masking in Settings

### DIFF
--- a/backend/open_webui/routers/pipelines.py
+++ b/backend/open_webui/routers/pipelines.py
@@ -57,7 +57,33 @@ def get_sorted_filters(model_id, models):
 
 
 async def process_pipeline_inlet_filter(request, payload, user, models):
-    user = {"id": user.id, "email": user.email, "name": user.name, "role": user.role}
+    # Extract user.settings as a plain dict. user.settings is a UserSettings
+    # Pydantic instance (models/users.py:40-43) with extra="allow", so arbitrary
+    # keys like "pipelines" survive model_dump(). The isinstance(dict) branch is
+    # defense-in-depth for unusual ORM states (e.g. raw dict from legacy data).
+    if user.settings is None:
+        user_settings_dict: dict = {}
+    elif isinstance(user.settings, dict):
+        user_settings_dict = user.settings
+    else:
+        user_settings_dict = user.settings.model_dump()
+
+    pipelines_settings = user_settings_dict.get("pipelines", {})
+    if not isinstance(pipelines_settings, dict):
+        pipelines_settings = {}
+
+    all_filter_valves = pipelines_settings.get("valves", {})
+    if not isinstance(all_filter_valves, dict):
+        all_filter_valves = {}
+
+    # user dict from openai.py is intentionally rebuilt here to inject
+    # per-user, per-filter valves. See TASK-3.7a-SPEC.md §3.2.
+    base_user_dict = {
+        "id": user.id,
+        "email": user.email,
+        "name": user.name,
+        "role": user.role,
+    }
     model_id = payload["model"]
     sorted_filters = get_sorted_filters(model_id, models)
     model = models[model_id]
@@ -83,9 +109,20 @@ async def process_pipeline_inlet_filter(request, payload, user, models):
             if not key:
                 continue
 
+            # Per-filter valves injection (TASK-3.7a). Each filter gets its own
+            # valves dict from user.settings["pipelines"]["valves"][filter_id].
+            filter_id = filter.get("id")
+            per_filter_valves = all_filter_valves.get(filter_id, {})
+            if not isinstance(per_filter_valves, dict):
+                per_filter_valves = {}
+            log.debug(
+                f"[pii_toggle] filter_id={filter_id} valves={per_filter_valves}"
+            )
+            user_with_valves = {**base_user_dict, "valves": per_filter_valves}
+
             headers = {"Authorization": f"Bearer {key}"}
             request_data = {
-                "user": user,
+                "user": user_with_valves,
                 "body": payload,
             }
 

--- a/backend/open_webui/routers/pipelines.py
+++ b/backend/open_webui/routers/pipelines.py
@@ -68,10 +68,11 @@ async def process_pipeline_inlet_filter(request, payload, user, models):
     else:
         user_settings_dict = user.settings.model_dump()
 
-    # SettingsModal.saveSettings persists everything wrapped under "ui"
-    # (see routes/+layout.svelte:737 and SettingsModal.svelte:558), so the
-    # stored shape is user.settings.ui.pipelines.valves.<filter_id>.<key>
-    # — not user.settings.pipelines.* as the spec originally assumed.
+    # Settings are stored under the "ui" key (frontend sends
+    # `updateUserSettings(..., { ui: ... })`; see SettingsModal.svelte:554-559).
+    # The stored shape is:
+    #   user.settings.ui.pipelines.valves.<filter_id>.<key>
+    # (not user.settings.pipelines.* as the spec originally assumed).
     ui_settings = user_settings_dict.get("ui", {})
     if not isinstance(ui_settings, dict):
         ui_settings = {}
@@ -118,13 +119,14 @@ async def process_pipeline_inlet_filter(request, payload, user, models):
                 continue
 
             # Per-filter valves injection (TASK-3.7a). Each filter gets its own
-            # valves dict from user.settings["pipelines"]["valves"][filter_id].
+            # valves dict from user.settings["ui"]["pipelines"]["valves"][filter_id].
             filter_id = filter.get("id")
             per_filter_valves = all_filter_valves.get(filter_id, {})
             if not isinstance(per_filter_valves, dict):
                 per_filter_valves = {}
             log.debug(
-                f"[pii_toggle] filter_id={filter_id} valves={per_filter_valves}"
+                f"[pii_toggle] filter_id={filter_id} "
+                f"pii_masking_enabled={per_filter_valves.get('pii_masking_enabled')}"
             )
             user_with_valves = {**base_user_dict, "valves": per_filter_valves}
 

--- a/backend/open_webui/routers/pipelines.py
+++ b/backend/open_webui/routers/pipelines.py
@@ -68,7 +68,15 @@ async def process_pipeline_inlet_filter(request, payload, user, models):
     else:
         user_settings_dict = user.settings.model_dump()
 
-    pipelines_settings = user_settings_dict.get("pipelines", {})
+    # SettingsModal.saveSettings persists everything wrapped under "ui"
+    # (see routes/+layout.svelte:737 and SettingsModal.svelte:558), so the
+    # stored shape is user.settings.ui.pipelines.valves.<filter_id>.<key>
+    # — not user.settings.pipelines.* as the spec originally assumed.
+    ui_settings = user_settings_dict.get("ui", {})
+    if not isinstance(ui_settings, dict):
+        ui_settings = {}
+
+    pipelines_settings = ui_settings.get("pipelines", {})
     if not isinstance(pipelines_settings, dict):
         pipelines_settings = {}
 

--- a/src/lib/components/chat/Settings/Privacy.svelte
+++ b/src/lib/components/chat/Settings/Privacy.svelte
@@ -71,6 +71,110 @@
 				)}
 			</div>
 		</div>
+
+		<div class="mt-6">
+			<div class="text-sm font-medium mb-3">Detected data types</div>
+
+			<div class="mb-4">
+				<div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+					Identity (10)
+				</div>
+				<div class="flex flex-wrap gap-2">
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>Person names</span
+					>
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>HR OIB</span
+					>
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>HR JMBG</span
+					>
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>IE PPSN</span
+					>
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>RO CNP</span
+					>
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>UK NINO</span
+					>
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>UK UTR</span
+					>
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>UK NHS</span
+					>
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>US SSN</span
+					>
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>US EIN</span
+					>
+				</div>
+			</div>
+
+			<div class="mb-4">
+				<div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+					Financial (6)
+				</div>
+				<div class="flex flex-wrap gap-2">
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>HR IBAN</span
+					>
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>IE IBAN</span
+					>
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>RO IBAN</span
+					>
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>GB IBAN</span
+					>
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>EU IBANs</span
+					>
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>Credit cards</span
+					>
+				</div>
+			</div>
+
+			<div>
+				<div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+					Contact &amp; Location (3)
+				</div>
+				<div class="flex flex-wrap gap-2">
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>Email addresses</span
+					>
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>Phone numbers</span
+					>
+					<span
+						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+						>Locations</span
+					>
+				</div>
+			</div>
+		</div>
 	</div>
 
 	<div class="flex justify-end text-sm font-medium">

--- a/src/lib/components/chat/Settings/Privacy.svelte
+++ b/src/lib/components/chat/Settings/Privacy.svelte
@@ -14,6 +14,35 @@
 	const dispatch = createEventDispatcher();
 	const i18n = getContext('i18n');
 
+	// Data types the PII masking pipeline detects, grouped for display. Mirrors the
+	// recognizers in pii_filter.py (PRESIDIO_TO_STANDARD). Counts shown in the UI are
+	// derived from each group's length, so adding/removing an entry keeps them in sync.
+	const detectedDataTypes: { label: string; items: string[] }[] = [
+		{
+			label: 'Identity',
+			items: [
+				'Person names',
+				'HR OIB',
+				'HR JMBG',
+				'IE PPSN',
+				'RO CNP',
+				'UK NINO',
+				'UK UTR',
+				'UK NHS',
+				'US SSN',
+				'US EIN'
+			]
+		},
+		{
+			label: 'Financial',
+			items: ['HR IBAN', 'IE IBAN', 'RO IBAN', 'GB IBAN', 'EU IBANs', 'Credit cards']
+		},
+		{
+			label: 'Contact & Location',
+			items: ['Email addresses', 'Phone numbers', 'Locations']
+		}
+	];
+
 	let piiMaskingEnabled = true;
 
 	onMount(() => {
@@ -75,104 +104,22 @@
 		<div class="mt-6">
 			<div class="text-sm font-medium mb-3">Detected data types</div>
 
-			<div class="mb-4">
-				<div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
-					Identity (10)
-				</div>
-				<div class="flex flex-wrap gap-2">
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>Person names</span
-					>
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>HR OIB</span
-					>
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>HR JMBG</span
-					>
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>IE PPSN</span
-					>
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>RO CNP</span
-					>
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>UK NINO</span
-					>
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>UK UTR</span
-					>
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>UK NHS</span
-					>
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>US SSN</span
-					>
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>US EIN</span
-					>
-				</div>
-			</div>
-
-			<div class="mb-4">
-				<div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
-					Financial (6)
-				</div>
-				<div class="flex flex-wrap gap-2">
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>HR IBAN</span
-					>
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>IE IBAN</span
-					>
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>RO IBAN</span
-					>
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>GB IBAN</span
-					>
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>EU IBANs</span
-					>
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>Credit cards</span
-					>
-				</div>
-			</div>
-
-			<div>
-				<div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
-					Contact &amp; Location (3)
-				</div>
-				<div class="flex flex-wrap gap-2">
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>Email addresses</span
-					>
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>Phone numbers</span
-					>
-					<span
-						class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
-						>Locations</span
-					>
-				</div>
+			<div class="space-y-4">
+				{#each detectedDataTypes as group}
+					<div>
+						<div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+							{group.label} ({group.items.length})
+						</div>
+						<div class="flex flex-wrap gap-2">
+							{#each group.items as item}
+								<span
+									class="px-3.5 py-1 rounded-full text-sm bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+									>{item}</span
+								>
+							{/each}
+						</div>
+					</div>
+				{/each}
 			</div>
 		</div>
 	</div>

--- a/src/lib/components/chat/Settings/Privacy.svelte
+++ b/src/lib/components/chat/Settings/Privacy.svelte
@@ -1,46 +1,57 @@
 <script lang="ts">
-	import { getContext, onMount } from 'svelte';
+	import { createEventDispatcher, getContext, onMount } from 'svelte';
 	import { settings } from '$lib/stores';
+	import { updateUserSettings } from '$lib/apis/users';
 	import Switch from '$lib/components/common/Switch.svelte';
 
-	const PII_FILTER_ID = 'pii_filter';
+	// Known PII filter pipeline IDs across deployed instances:
+	//   "pii_filter"           — pii-filter repo (pii_filter.py)
+	//   "pii_filter_pipeline"  — pipelines-v4 repo + GCP deployment (pii_filter_pipeline.py)
+	// The OpenWebUI bridge keys per-filter valves by the runtime filter id, so we
+	// mirror the toggle under every known id to cover whichever pipeline is wired up.
+	const PII_FILTER_IDS = ['pii_filter', 'pii_filter_pipeline'] as const;
 
+	const dispatch = createEventDispatcher();
 	const i18n = getContext('i18n');
-
-	export let saveSettings: Function;
 
 	let piiMaskingEnabled = true;
 
 	onMount(() => {
-		const s = $settings as any;
-		piiMaskingEnabled = s?.pipelines?.valves?.[PII_FILTER_ID]?.pii_masking_enabled ?? true;
-	});
-
-	async function onPiiMaskingChange() {
-		const s = $settings as any;
-		const pipelines = (s?.pipelines ?? {}) as Record<string, any>;
-		const valves = (pipelines.valves ?? {}) as Record<string, any>;
-		const filterValves = (valves[PII_FILTER_ID] ?? {}) as Record<string, any>;
-
-		await saveSettings({
-			pipelines: {
-				...pipelines,
-				valves: {
-					...valves,
-					[PII_FILTER_ID]: {
-						...filterValves,
-						pii_masking_enabled: piiMaskingEnabled
-					}
-				}
+		const valves = ($settings as any)?.pipelines?.valves ?? {};
+		for (const id of PII_FILTER_IDS) {
+			const v = valves?.[id]?.pii_masking_enabled;
+			if (typeof v === 'boolean') {
+				piiMaskingEnabled = v;
+				return;
 			}
-		});
-	}
+		}
+	});
 </script>
 
 <form
 	id="tab-privacy"
 	class="flex flex-col h-full justify-between space-y-3 text-sm"
-	on:submit|preventDefault
+	on:submit|preventDefault={async () => {
+		const s = ($settings ?? {}) as any;
+		const pipelines = (s.pipelines ?? {}) as Record<string, any>;
+		const existingValves = (pipelines.valves ?? {}) as Record<string, any>;
+
+		const valves: Record<string, any> = { ...existingValves };
+		for (const id of PII_FILTER_IDS) {
+			valves[id] = {
+				...(existingValves[id] ?? {}),
+				pii_masking_enabled: piiMaskingEnabled
+			};
+		}
+
+		// Persist directly to avoid the shared saveSettings model refresh, which
+		// blocks on /api/models and stalls the toast when a provider (e.g. Ollama)
+		// is unreachable.
+		const next = { ...s, pipelines: { ...pipelines, valves } };
+		await settings.set(next);
+		await updateUserSettings(localStorage.token, { ui: next });
+		dispatch('save');
+	}}
 >
 	<div class="py-1 overflow-y-scroll max-h-[28rem] md:max-h-full">
 		<div>
@@ -50,15 +61,24 @@
 				</div>
 
 				<div class="">
-					<Switch bind:state={piiMaskingEnabled} on:change={onPiiMaskingChange} />
+					<Switch bind:state={piiMaskingEnabled} />
 				</div>
 			</div>
 
 			<div class="text-xs text-gray-500">
 				{$i18n.t(
-					'When ON, personal data (names, OIBs, IBANs, emails, etc.) is automatically replaced with placeholders before being sent to the AI model.'
+					'When ON, personal data (names, IBANs, emails, etc.) is automatically replaced with placeholders before being sent to the AI model.'
 				)}
 			</div>
 		</div>
+	</div>
+
+	<div class="flex justify-end text-sm font-medium">
+		<button
+			class="px-3.5 py-1.5 text-sm font-medium bg-black hover:bg-gray-900 text-white dark:bg-white dark:text-black dark:hover:bg-gray-100 transition rounded-full"
+			type="submit"
+		>
+			{$i18n.t('Save')}
+		</button>
 	</div>
 </form>

--- a/src/lib/components/chat/Settings/Privacy.svelte
+++ b/src/lib/components/chat/Settings/Privacy.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import { getContext, onMount } from 'svelte';
+	import { settings } from '$lib/stores';
+	import Switch from '$lib/components/common/Switch.svelte';
+
+	const PII_FILTER_ID = 'pii_filter';
+
+	const i18n = getContext('i18n');
+
+	export let saveSettings: Function;
+
+	let piiMaskingEnabled = true;
+
+	onMount(() => {
+		const s = $settings as any;
+		piiMaskingEnabled = s?.pipelines?.valves?.[PII_FILTER_ID]?.pii_masking_enabled ?? true;
+	});
+
+	async function onPiiMaskingChange() {
+		const s = $settings as any;
+		const pipelines = (s?.pipelines ?? {}) as Record<string, any>;
+		const valves = (pipelines.valves ?? {}) as Record<string, any>;
+		const filterValves = (valves[PII_FILTER_ID] ?? {}) as Record<string, any>;
+
+		await saveSettings({
+			pipelines: {
+				...pipelines,
+				valves: {
+					...valves,
+					[PII_FILTER_ID]: {
+						...filterValves,
+						pii_masking_enabled: piiMaskingEnabled
+					}
+				}
+			}
+		});
+	}
+</script>
+
+<form
+	id="tab-privacy"
+	class="flex flex-col h-full justify-between space-y-3 text-sm"
+	on:submit|preventDefault
+>
+	<div class="py-1 overflow-y-scroll max-h-[28rem] md:max-h-full">
+		<div>
+			<div class="flex items-center justify-between mb-1">
+				<div class="text-sm font-medium">
+					{$i18n.t('Enable PII masking')}
+				</div>
+
+				<div class="">
+					<Switch bind:state={piiMaskingEnabled} on:change={onPiiMaskingChange} />
+				</div>
+			</div>
+
+			<div class="text-xs text-gray-500">
+				{$i18n.t(
+					'When ON, personal data (names, OIBs, IBANs, emails, etc.) is automatically replaced with placeholders before being sent to the AI model.'
+				)}
+			</div>
+		</div>
+	</div>
+</form>

--- a/src/lib/components/chat/Settings/Privacy.svelte
+++ b/src/lib/components/chat/Settings/Privacy.svelte
@@ -56,12 +56,12 @@
 	<div class="py-1 overflow-y-scroll max-h-[28rem] md:max-h-full">
 		<div>
 			<div class="flex items-center justify-between mb-1">
-				<div class="text-sm font-medium">
+				<div id="pii-masking-label" class="text-sm font-medium">
 					{$i18n.t('Enable PII masking')}
 				</div>
 
 				<div class="">
-					<Switch bind:state={piiMaskingEnabled} />
+					<Switch ariaLabelledbyId="pii-masking-label" bind:state={piiMaskingEnabled} />
 				</div>
 			</div>
 

--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -14,11 +14,13 @@
 	import Audio from './Settings/Audio.svelte';
 	import DataControls from './Settings/DataControls.svelte';
 	import Personalization from './Settings/Personalization.svelte';
+	import Privacy from './Settings/Privacy.svelte';
 	import Search from '../icons/Search.svelte';
 	import XMark from '../icons/XMark.svelte';
 	import Connections from './Settings/Connections.svelte';
 	import Tools from './Settings/Tools.svelte';
 	import DatabaseSettings from '../icons/DatabaseSettings.svelte';
+	import LockClosed from '../icons/LockClosed.svelte';
 	import SettingsAlt from '../icons/SettingsAlt.svelte';
 	import Link from '../icons/Link.svelte';
 	import UserCircle from '../icons/UserCircle.svelte';
@@ -253,6 +255,27 @@
 				'profile',
 				'user preferences',
 				'userpreferences'
+			]
+		},
+		{
+			id: 'privacy',
+			title: 'Privacy & PII',
+			keywords: [
+				'pii',
+				'pii masking',
+				'piimasking',
+				'privacy',
+				'privacy settings',
+				'privacysettings',
+				'personal data',
+				'personaldata',
+				'mask',
+				'masking',
+				'oib',
+				'iban',
+				'gdpr',
+				'data protection',
+				'dataprotection'
 			]
 		},
 		{
@@ -747,6 +770,30 @@
 								</div>
 								<div class=" self-center">{$i18n.t('Personalization')}</div>
 							</button>
+						{:else if tabId === 'privacy'}
+							<button
+								role="tab"
+								aria-controls="tab-privacy"
+								aria-selected={selectedTab === 'privacy'}
+								class={`px-0.5 md:px-2.5 py-1 min-w-fit rounded-xl flex-1 md:flex-none flex text-left transition
+								${
+									selectedTab === 'privacy'
+										? ($settings?.highContrastMode ?? false)
+											? 'dark:bg-gray-800 bg-gray-200'
+											: ''
+										: ($settings?.highContrastMode ?? false)
+											? 'hover:bg-gray-200 dark:hover:bg-gray-800'
+											: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'
+								}`}
+								on:click={() => {
+									selectedTab = 'privacy';
+								}}
+							>
+								<div class=" self-center mr-2">
+									<LockClosed strokeWidth="2" />
+								</div>
+								<div class=" self-center">{$i18n.t('Privacy & PII')}</div>
+							</button>
 						{:else if tabId === 'audio'}
 							<button
 								role="tab"
@@ -906,6 +953,8 @@
 							toast.success($i18n.t('Settings saved successfully!'));
 						}}
 					/>
+				{:else if selectedTab === 'privacy'}
+					<Privacy {saveSettings} />
 				{:else if selectedTab === 'audio'}
 					<Audio
 						{saveSettings}

--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -954,7 +954,11 @@
 						}}
 					/>
 				{:else if selectedTab === 'privacy'}
-					<Privacy {saveSettings} />
+					<Privacy
+						on:save={() => {
+							toast.success($i18n.t('Settings saved successfully!'));
+						}}
+					/>
 				{:else if selectedTab === 'audio'}
 					<Audio
 						{saveSettings}


### PR DESCRIPTION
## Summary
  Adds user-facing Privacy & PII toggle in Settings that lets each user enable/disable PII masking on the pipeline filter. Frontend writes the toggle into `user.settings.ui.pipelines.valves.<filter_id>.pii_masking_enabled`; backend `process_pipeline_inlet_filter` reads it from the same path and injects per-filter `valves` into the request sent to the pipeline. Defaults to ON (privacy-by-default).

  ## Changes
  - **`src/lib/components/chat/Settings/Privacy.svelte`** (new) — toggle UI with explicit Save button; writes under both known pipeline IDs (`pii_filter` and
  `pii_filter_pipeline`); bypasses shared `saveSettings` to avoid `/api/models` stall that delays the toast.
  - **`src/lib/components/chat/SettingsModal.svelte`** — registers the Privacy & PII tab + `on:save` toast handler.
  - **`backend/open_webui/routers/pipelines.py`** — reads per-filter valves from `user.settings.ui.pipelines.valves[filter_id]` and injects them into the `user` dict   passed to each filter.

  ## Test plan
  - [x] Manual: open Settings → Privacy & PII, toggle off, Save → toast fires instantly, value persists across reload.
  - [x] Manual: send chat with toggle ON → PII (names, IBANs, emails) is masked before reaching the model.
  - [x] Manual: send chat with toggle OFF → no masking applied.

<img width="1300" height="750" alt="image" src="https://github.com/user-attachments/assets/3e90bf5f-4ff3-4d01-be1e-bdf0989f61ef" />


