### PR TITLE
feat(TRAU-462): track LLM token usage...

### DIFF
--- a/backend/open_webui/routers/tasks.py
+++ b/backend/open_webui/routers/tasks.py
@@ -61,7 +61,6 @@ async def _report_task_usage(
         if choices:
             assistant_content = choices[0].get("message", {}).get("content", "")
         chat_id = payload.get("metadata", {}).get("chat_id")
-        task_name = payload.get("metadata", {}).get("task", "unknown_task")
         if not chat_id:
             return
         outlet_body = {
@@ -75,6 +74,7 @@ async def _report_task_usage(
                     "usage": usage,
                 }
             ],
+            "metadata": payload.get("metadata", {}),
         }
         await process_pipeline_outlet_filter(request, outlet_body, user, models)
     except Exception as exc:

--- a/backend/open_webui/routers/tasks.py
+++ b/backend/open_webui/routers/tasks.py
@@ -20,7 +20,7 @@ from open_webui.utils.task import (
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.constants import TASKS
 
-from open_webui.routers.pipelines import process_pipeline_inlet_filter
+from open_webui.routers.pipelines import process_pipeline_inlet_filter, process_pipeline_outlet_filter
 
 from open_webui.utils.task import get_task_model_id
 
@@ -40,6 +40,45 @@ from open_webui.config import (
 log = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+async def _report_task_usage(
+    request,
+    user,
+    payload: dict,
+    response,
+    models: dict,
+) -> None:
+    """Report task LLM usage to the pipeline outlet so Langfuse records it."""
+    try:
+        if not isinstance(response, dict):
+            return
+        usage = response.get("usage") or {}
+        if not usage:
+            return
+        choices = response.get("choices", [])
+        assistant_content = ""
+        if choices:
+            assistant_content = choices[0].get("message", {}).get("content", "")
+        chat_id = payload.get("metadata", {}).get("chat_id")
+        task_name = payload.get("metadata", {}).get("task", "unknown_task")
+        if not chat_id:
+            return
+        outlet_body = {
+            "chat_id": chat_id,
+            "model": payload["model"],
+            "messages": payload["messages"]
+            + [
+                {
+                    "role": "assistant",
+                    "content": assistant_content,
+                    "usage": usage,
+                }
+            ],
+        }
+        await process_pipeline_outlet_filter(request, outlet_body, user, models)
+    except Exception as exc:
+        log.warning(f"_report_task_usage failed: {exc}")
 
 
 ##################################
@@ -236,7 +275,9 @@ async def generate_title(
         raise e
 
     try:
-        return await generate_chat_completion(request, form_data=payload, user=user)
+        response = await generate_chat_completion(request, form_data=payload, user=user)
+        await _report_task_usage(request, user, payload, response, models)
+        return response
     except Exception as e:
         log.error("Exception occurred", exc_info=True)
         return JSONResponse(
@@ -309,7 +350,9 @@ async def generate_follow_ups(
         raise e
 
     try:
-        return await generate_chat_completion(request, form_data=payload, user=user)
+        response = await generate_chat_completion(request, form_data=payload, user=user)
+        await _report_task_usage(request, user, payload, response, models)
+        return response
     except Exception as e:
         log.error("Exception occurred", exc_info=True)
         return JSONResponse(
@@ -382,7 +425,9 @@ async def generate_chat_tags(
         raise e
 
     try:
-        return await generate_chat_completion(request, form_data=payload, user=user)
+        response = await generate_chat_completion(request, form_data=payload, user=user)
+        await _report_task_usage(request, user, payload, response, models)
+        return response
     except Exception as e:
         log.error(f"Error generating chat completion: {e}")
         return JSONResponse(

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -36,6 +36,7 @@ from open_webui.routers.pipelines import (
     process_pipeline_outlet_filter,
 )
 
+from open_webui.models.chats import Chats as _Chats
 from open_webui.models.functions import Functions
 from open_webui.models.models import Models
 
@@ -318,6 +319,22 @@ async def chat_completed(request: Request, form_data: dict, user: Any):
 
     model = models[model_id]
 
+    # If last assistant message has no usage, fall back to DB (race condition fix:
+    # frontend may send /api/chat/completed before the streaming usage socket event arrives)
+    _messages = data.get("messages", [])
+    _last_asst = next(
+        (m for m in reversed(_messages) if m.get("role") == "assistant"), None
+    )
+    if _last_asst and not _last_asst.get("usage"):
+        _chat_id = data.get("chat_id")
+        _db_msg_id = _last_asst.get("id")
+        if _chat_id and _db_msg_id:
+            _chat = _Chats.get_chat_by_id(_chat_id)
+            if _chat:
+                _history = _chat.chat.get("history", {}).get("messages", {})
+                _db_usage = _history.get(_db_msg_id, {}).get("usage")
+                if _db_usage:
+                    _last_asst["usage"] = _db_usage
     try:
         data = await process_pipeline_outlet_filter(request, data, user, models)
     except Exception as e:

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -329,10 +329,8 @@ async def chat_completed(request: Request, form_data: dict, user: Any):
         _chat_id = data.get("chat_id")
         _db_msg_id = _last_asst.get("id")
         if _chat_id and _db_msg_id:
-            _chat = _Chats.get_chat_by_id(_chat_id)
-            if _chat:
-                _history = _chat.chat.get("history", {}).get("messages", {})
-                _db_usage = _history.get(_db_msg_id, {}).get("usage")
+                _db_msg = _Chats.get_message_by_id_and_message_id(_chat_id, _db_msg_id)
+                _db_usage = (_db_msg or {}).get("usage")
                 if _db_usage:
                     _last_asst["usage"] = _db_usage
     try:

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2854,6 +2854,11 @@ async def process_chat_response(
                                     usage = data.get("usage", {}) or {}
                                     usage.update(data.get("timings", {}))  # llama.cpp
                                     if usage:
+                                        Chats.upsert_message_to_chat_by_id_and_message_id(
+                                            metadata["chat_id"],
+                                            metadata["message_id"],
+                                            {"usage": usage},
+                                        )
                                         await event_emitter(
                                             {
                                                 "type": "chat:completion",

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2854,11 +2854,6 @@ async def process_chat_response(
                                     usage = data.get("usage", {}) or {}
                                     usage.update(data.get("timings", {}))  # llama.cpp
                                     if usage:
-                                        Chats.upsert_message_to_chat_by_id_and_message_id(
-                                            metadata["chat_id"],
-                                            metadata["message_id"],
-                                            {"usage": usage},
-                                        )
                                         await event_emitter(
                                             {
                                                 "type": "chat:completion",
@@ -2867,6 +2862,14 @@ async def process_chat_response(
                                                 },
                                             }
                                         )
+                                        try:
+                                            Chats.upsert_message_to_chat_by_id_and_message_id(
+                                                metadata["chat_id"],
+                                                metadata["message_id"],
+                                                {"usage": usage},
+                                            )
+                                        except Exception as e:
+                                            log.warning(f"failed to persist usage: {e}")
 
                                     if not choices:
                                         error = data.get("error", {})


### PR DESCRIPTION
… in Langfuse for main chat and background tasks

- middleware.py: persist streaming usage to DB immediately when usage chunk arrives, so it is available before /api/chat/completed is called (race condition fix)
- chat.py: in chat_completed(), fall back to DB usage if the outlet body's last assistant message has no usage field (handles race condition with streaming)
- tasks.py: add _report_task_usage() helper that calls process_pipeline_outlet_filter after each task LLM call (title, follow-up, tags) so Langfuse records task tokens

