### PR TITLE
STAGING: feature/TRAU-486

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1505,7 +1505,7 @@
 											id="input-menu-button"
 											class="bg-transparent hover:bg-hg-bg-muted dark:hover:bg-gray-700 text-hg-text-secondary dark:text-gray-400 rounded-full size-8 flex justify-center items-center outline-hidden focus:outline-hidden"
 										>
-											<HgIconPlus class="w-5 h-5" />
+											<HgIconPlus class="w-5 h-5 text-hg-text-tertiary dark:text-gray-400" />
 										</div>
 									</InputMenu>
 

--- a/src/lib/components/chat/ModelSelector.svelte
+++ b/src/lib/components/chat/ModelSelector.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { models, showSettings, settings, user, mobile, config } from '$lib/stores';
-	import { onMount, tick, getContext } from 'svelte';
+	import { models, settings, user } from '$lib/stores';
+	import { getContext } from 'svelte';
 	import { toast } from 'svelte-sonner';
 	import Selector from './ModelSelector/Selector.svelte';
 	import Tooltip from '../common/Tooltip.svelte';
@@ -25,7 +25,7 @@
 		toast.success($i18n.t('Default model updated'));
 	};
 
-	const pinModelHandler = async (modelId) => {
+	const pinModelHandler = async (modelId: string) => {
 		let pinnedModels = $settings?.pinnedModels ?? [];
 
 		if (pinnedModels.includes(modelId)) {
@@ -129,7 +129,7 @@
 
 {#if showSetDefault}
 	<div
-		class="relative text-left mt-[1px] ml-1 text-[0.7rem] text-gray-600 dark:text-gray-400 font-primary"
+		class="relative text-left mt-px ml-1 text-[0.7rem] text-gray-600 dark:text-gray-400 font-primary"
 	>
 		{#if JSON.stringify(selectedModels) === JSON.stringify($settings?.models ?? [])}
 			<span>{$i18n.t('Default model')}</span>

--- a/src/lib/components/chat/ModelSelector/ModelItem.svelte
+++ b/src/lib/components/chat/ModelSelector/ModelItem.svelte
@@ -1,22 +1,17 @@
 <script lang="ts">
-	import { marked } from 'marked';
+	import { getContext } from 'svelte';
 
-	import { getContext, tick } from 'svelte';
-	import dayjs from '$lib/dayjs';
-
-	import { mobile, settings, user, theme } from '$lib/stores';
-	import { WEBUI_API_BASE_URL, WEBUI_BASE_URL } from '$lib/constants';
+	import { user, theme } from '$lib/stores';
+	import { WEBUI_API_BASE_URL } from '$lib/constants';
 
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
-	import { copyToClipboard, sanitizeResponseContent } from '$lib/utils';
+	import { copyToClipboard } from '$lib/utils';
 	import { resolveTheme } from '$lib/utils/theme';
 	import ArrowUpTray from '$lib/components/icons/ArrowUpTray.svelte';
 	import Check from '$lib/components/icons/Check.svelte';
 	import ModelItemMenu from './ModelItemMenu.svelte';
-	import EllipsisHorizontal from '$lib/components/icons/EllipsisHorizontal.svelte';
+	import EllipsisVertical from '$lib/components/icons/EllipsisVertical.svelte';
 	import { toast } from 'svelte-sonner';
-	import Tag from '$lib/components/icons/Tag.svelte';
-	import Label from '$lib/components/icons/Label.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -45,14 +40,43 @@
 
 	// Resolve theme to 'light' or 'dark' for API call
 	$: resolvedTheme = resolveTheme($theme);
+
+	// providerName prop is only set by featured entries (curated brand name e.g. "Google").
+	// For All/Local tabs owned_by is infrastructure ("ollama"), not the model brand — ignore it.
+	$: providerDisplay = (item?.providerName as string) ?? '';
+
+	// Line 1 two-tone split: provider name in primary, model name in tertiary.
+	// With explicit provider: nameHead = provider, nameTail = full label.
+	// Without provider: split label on first space as before.
+	$: nameHead = (() => {
+		if (providerDisplay) return providerDisplay;
+		const label = (item?.label ?? '').trim();
+		const spaceIdx = label.indexOf(' ');
+		return spaceIdx === -1 ? label : label.slice(0, spaceIdx);
+	})();
+	$: nameTail = (() => {
+		const label = (item?.label ?? '').trim();
+		if (providerDisplay) return label;
+		const spaceIdx = label.indexOf(' ');
+		return spaceIdx === -1 ? '' : label.slice(spaceIdx + 1).trim();
+	})();
+
+	// Line 2 capability string: model tags joined, else fall back to description.
+	$: capabilityLine = (() => {
+		const tags = (item?.model?.tags ?? []).map((t: { name?: string }) => t?.name).filter(Boolean);
+		if (tags.length > 0) {
+			return tags.join(' • ');
+		}
+		return (item?.model?.info?.meta?.description ?? '').trim();
+	})();
 </script>
 
 <button
 	aria-roledescription="model-item"
 	aria-label={item.label}
-	class="flex group/item w-full text-left font-medium line-clamp-1 select-none items-center rounded-button py-2 pl-3 pr-1.5 text-sm text-gray-700 dark:text-gray-100 outline-hidden transition-all duration-75 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-xl cursor-pointer data-highlighted:bg-muted {index ===
+	class="flex group/item w-full text-left select-none items-center rounded-xl px-3 py-2 outline-hidden transition-all duration-75 hover:bg-hg-bg-muted dark:hover:bg-gray-800 cursor-pointer {index ===
 	selectedModelIdx
-		? 'bg-gray-100 dark:bg-gray-800 group-hover:bg-transparent'
+		? 'bg-hg-bg-muted dark:bg-gray-800 group-hover:bg-transparent'
 		: ''}"
 	data-arrow-selected={index === selectedModelIdx}
 	data-value={item.value}
@@ -60,174 +84,26 @@
 		onClick();
 	}}
 >
-	<div class="flex flex-col flex-1 gap-1.5">
-		<!-- {#if (item?.model?.tags ?? []).length > 0}
-			<div
-				class="flex gap-0.5 self-center items-start h-full w-full translate-y-[0.5px] overflow-x-auto scrollbar-none"
-			>
-				{#each item.model?.tags.sort((a, b) => a.name.localeCompare(b.name)) as tag}
-					<Tooltip content={tag.name} className="flex-shrink-0">
-						<div
-							class=" text-xs font-semibold px-1 rounded-sm uppercase bg-gray-500/20 text-gray-700 dark:text-gray-200"
-						>
-							{tag.name}
-						</div>
-					</Tooltip>
-				{/each}
-			</div>
-		{/if} -->
-
-		<div class="flex items-center gap-2">
-			<div class="flex items-center min-w-fit">
-				<Tooltip content={$user?.role === 'admin' ? (item?.value ?? '') : ''} placement="top-start">
-					<img
-						src={`${WEBUI_API_BASE_URL}/models/model/profile/image?id=${item.model.id}&theme=${resolvedTheme}&lang=${$i18n.language}`}
-						alt="Model"
-						class="rounded-full size-5 flex items-center"
-						loading="lazy"
-					/>
-				</Tooltip>
-			</div>
-
-			<div class="flex items-center">
-				<Tooltip content={`${item.label} (${item.value})`} placement="top-start">
-					<div class="line-clamp-1">
-						{item.label}
-					</div>
-				</Tooltip>
-			</div>
-
-			<div class=" shrink-0 flex items-center gap-2">
-				{#if item.model.owned_by === 'ollama'}
-					{#if (item.model.ollama?.details?.parameter_size ?? '') !== ''}
-						<div class="flex items-center translate-y-[0.5px]">
-							<Tooltip
-								content={`${
-									item.model.ollama?.details?.quantization_level
-										? item.model.ollama?.details?.quantization_level + ' '
-										: ''
-								}${
-									item.model.ollama?.size
-										? `(${(item.model.ollama?.size / 1024 ** 3).toFixed(1)}GB)`
-										: ''
-								}`}
-								className="self-end"
-							>
-								<span class=" text-xs font-medium text-gray-600 dark:text-gray-400 line-clamp-1"
-									>{item.model.ollama?.details?.parameter_size ?? ''}</span
-								>
-							</Tooltip>
-						</div>
-					{/if}
-					{#if item.model.ollama?.expires_at && new Date(item.model.ollama?.expires_at * 1000) > new Date()}
-						<div class="flex items-center translate-y-[0.5px] px-0.5">
-							<Tooltip
-								content={`${$i18n.t('Unloads {{FROM_NOW}}', {
-									FROM_NOW: dayjs(item.model.ollama?.expires_at * 1000).fromNow()
-								})}`}
-								className="self-end"
-							>
-								<div class=" flex items-center">
-									<span class="relative flex size-2">
-										<span
-											class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"
-										></span>
-										<span class="relative inline-flex rounded-full size-2 bg-green-500"></span>
-									</span>
-								</div>
-							</Tooltip>
-						</div>
-					{/if}
-				{/if}
-
-				<!-- {JSON.stringify(item.info)} -->
-
-				{#if (item?.model?.tags ?? []).length > 0}
-					{#key item.model.id}
-						<Tooltip elementId="tags-{item.model.id}">
-							<div slot="tooltip" id="tags-{item.model.id}">
-								{#each item.model?.tags.sort((a, b) => a.name.localeCompare(b.name)) as tag}
-									<Tooltip content={tag.name} className="flex-shrink-0">
-										<div class=" text-xs font-medium rounded-sm uppercase text-white">
-											{tag.name}
-										</div>
-									</Tooltip>
-								{/each}
-							</div>
-
-							<div class="translate-y-[1px]">
-								<Tag />
-							</div>
-						</Tooltip>
-					{/key}
-				{/if}
-
-				{#if item.model?.direct}
-					<Tooltip content={`${$i18n.t('Direct')}`}>
-						<div class="translate-y-[1px]">
-							<svg
-								xmlns="http://www.w3.org/2000/svg"
-								viewBox="0 0 16 16"
-								fill="currentColor"
-								class="size-3"
-							>
-								<path
-									fill-rule="evenodd"
-									d="M2 2.75A.75.75 0 0 1 2.75 2C8.963 2 14 7.037 14 13.25a.75.75 0 0 1-1.5 0c0-5.385-4.365-9.75-9.75-9.75A.75.75 0 0 1 2 2.75Zm0 4.5a.75.75 0 0 1 .75-.75 6.75 6.75 0 0 1 6.75 6.75.75.75 0 0 1-1.5 0C8 10.35 5.65 8 2.75 8A.75.75 0 0 1 2 7.25ZM3.5 11a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Z"
-									clip-rule="evenodd"
-								/>
-							</svg>
-						</div>
-					</Tooltip>
-				{:else if item.model.connection_type === 'external'}
-					<Tooltip content={`${$i18n.t('External')}`}>
-						<div class="translate-y-[1px]">
-							<svg
-								xmlns="http://www.w3.org/2000/svg"
-								viewBox="0 0 16 16"
-								fill="currentColor"
-								class="size-3"
-							>
-								<path
-									fill-rule="evenodd"
-									d="M8.914 6.025a.75.75 0 0 1 1.06 0 3.5 3.5 0 0 1 0 4.95l-2 2a3.5 3.5 0 0 1-5.396-4.402.75.75 0 0 1 1.251.827 2 2 0 0 0 3.085 2.514l2-2a2 2 0 0 0 0-2.828.75.75 0 0 1 0-1.06Z"
-									clip-rule="evenodd"
-								/>
-								<path
-									fill-rule="evenodd"
-									d="M7.086 9.975a.75.75 0 0 1-1.06 0 3.5 3.5 0 0 1 0-4.95l2-2a3.5 3.5 0 0 1 5.396 4.402.75.75 0 0 1-1.251-.827 2 2 0 0 0-3.085-2.514l-2 2a2 2 0 0 0 0 2.828.75.75 0 0 1 0 1.06Z"
-									clip-rule="evenodd"
-								/>
-							</svg>
-						</div>
-					</Tooltip>
-				{/if}
-
-				{#if item.model?.info?.meta?.description}
-					<Tooltip
-						content={`${marked.parse(
-							sanitizeResponseContent(item.model?.info?.meta?.description).replaceAll('\n', '<br>')
-						)}`}
-					>
-						<div class=" translate-y-[1px]">
-							<svg
-								xmlns="http://www.w3.org/2000/svg"
-								fill="none"
-								viewBox="0 0 24 24"
-								stroke-width="1.5"
-								stroke="currentColor"
-								class="w-4 h-4"
-							>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"
-								/>
-							</svg>
-						</div>
-					</Tooltip>
-				{/if}
-			</div>
+	<div class="flex flex-[1_0_0] items-center gap-2 min-w-px">
+		<Tooltip content={$user?.role === 'admin' ? (item?.value ?? '') : ''} placement="top-start">
+			<img
+				src={`${WEBUI_API_BASE_URL}/models/model/profile/image?id=${item.model.id}&theme=${resolvedTheme}&lang=${$i18n.language}`}
+				alt="Model"
+				class="rounded-full size-5 shrink-0"
+				loading="lazy"
+			/>
+		</Tooltip>
+		<div class="flex flex-[1_0_0] flex-col gap-1 items-start min-w-px">
+			<span class="font-semibold text-base truncate w-full leading-[1.4]">
+				<span class="text-hg-text-primary dark:text-gray-100">{nameHead}</span>{#if nameTail}<span
+						class="text-hg-text-tertiary dark:text-gray-500">{' '}– {nameTail}</span
+					>{/if}
+			</span>
+			{#if capabilityLine}
+				<p class="text-xs text-hg-text-tertiary dark:text-gray-500 truncate w-full leading-[1.4]">
+					{capabilityLine}
+				</p>
+			{/if}
 		</div>
 	</div>
 
@@ -235,7 +111,7 @@
 		{#if $user?.role === 'admin' && item.model.owned_by === 'ollama' && item.model.ollama?.expires_at && new Date(item.model.ollama?.expires_at * 1000) > new Date()}
 			<Tooltip
 				content={`${$i18n.t('Eject')}`}
-				className="flex-shrink-0 group-hover/item:opacity-100 opacity-0 "
+				className="shrink-0 group-hover/item:opacity-100 opacity-0"
 			>
 				<button
 					class="flex"
@@ -248,6 +124,12 @@
 					<ArrowUpTray className="size-3" />
 				</button>
 			</Tooltip>
+		{/if}
+
+		{#if value === item.value}
+			<div class="shrink-0">
+				<Check className="size-5 text-hg-blue dark:text-gray-400" />
+			</div>
 		{/if}
 
 		<ModelItemMenu
@@ -267,14 +149,8 @@
 					showMenu = !showMenu;
 				}}
 			>
-				<EllipsisHorizontal />
+				<EllipsisVertical className="size-5 text-hg-text-tertiary dark:text-gray-500" />
 			</button>
 		</ModelItemMenu>
-
-		{#if value === item.value}
-			<div>
-				<Check className="size-3" />
-			</div>
-		{/if}
 	</div>
 </button>

--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -19,14 +19,18 @@
 		mobile,
 		temporaryChatEnabled,
 		settings,
-		config
+		config,
+		theme
 	} from '$lib/stores';
 	import { toast } from 'svelte-sonner';
 	import { capitalizeFirstLetter, sanitizeResponseContent, splitStream } from '$lib/utils';
+	import { resolveTheme } from '$lib/utils/theme';
+	import { WEBUI_API_BASE_URL } from '$lib/constants';
 	import { getModels } from '$lib/apis';
 	import { getFeaturedModels } from '$lib/apis/configs';
+	import { updateUserSettings } from '$lib/apis/users';
 
-	import ChevronDown from '$lib/components/icons/ChevronDown.svelte';
+	import HgIconChevronRight from '$lib/components/icons/HgIconChevronRight.svelte';
 	import Search from '$lib/components/icons/Search.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 
@@ -49,7 +53,6 @@
 		[key: string]: any;
 	}[] = [];
 
-	export let className = 'w-[32rem]';
 	export let triggerClassName = 'text-lg';
 
 	export let pinModelHandler: (modelId: string) => void = () => {};
@@ -61,6 +64,30 @@
 
 	let selectedModel = '';
 	$: selectedModel = items.find((item) => item.value === value) ?? '';
+
+	$: resolvedTheme = resolveTheme($theme);
+
+	$: selectedNameHead = (() => {
+		if (!selectedModel) return '';
+		const label = (selectedModel.label ?? '').trim();
+		const spaceIdx = label.indexOf(' ');
+		return spaceIdx === -1 ? label : label.slice(0, spaceIdx);
+	})();
+
+	$: selectedNameTail = (() => {
+		if (!selectedModel) return '';
+		const label = (selectedModel.label ?? '').trim();
+		const spaceIdx = label.indexOf(' ');
+		return spaceIdx === -1 ? '' : label.slice(spaceIdx + 1).trim();
+	})();
+
+	$: isCurrentModelDefault = ($settings?.models?.[0] ?? '') === value;
+
+	const toggleDefaultModel = async () => {
+		const newDefault = isCurrentModelDefault ? '' : value;
+		await settings.set({ ...$settings, models: newDefault ? [newDefault] : [] });
+		await updateUserSettings(localStorage.token, { ui: $settings });
+	};
 
 	let searchValue = '';
 
@@ -76,16 +103,36 @@
 	}[] = [];
 
 	$: availableIds = new Set(
-		items
-			.filter((item) => !(item.model?.info?.meta?.hidden ?? false))
-			.map((item) => item.value)
+		items.filter((item) => !(item.model?.info?.meta?.hidden ?? false)).map((item) => item.value)
 	);
 
-	$: featuredModels = rawFeaturedModels.length > 0
-		? [...rawFeaturedModels]
-			.filter((m) => availableIds.has(m.model_id))
-			.sort((a, b) => a.order - b.order)
-		: [];
+	$: featuredModels =
+		rawFeaturedModels.length > 0
+			? [...rawFeaturedModels]
+					.filter((m) => availableIds.has(m.model_id))
+					.sort((a, b) => a.order - b.order)
+			: [];
+
+	// Map a featured entry onto the `item` shape ModelItem consumes, reusing the
+	// real backing model (logo, menu) while overriding the display name/tags with
+	// the curated featured values. Only entries with a backing item are rendered
+	// (featuredModels is already filtered to availableIds), so the lookup is safe.
+	const featuredToItem = (entry: (typeof rawFeaturedModels)[number]) => {
+		const backing = items.find((item) => item.value === entry.model_id);
+		const featuredTags = (entry.tags ?? []).filter(Boolean).map((name) => ({ name }));
+
+		return {
+			...backing,
+			value: entry.model_id,
+			label: entry.featured_name || backing?.label,
+			providerName: entry.provider_name || undefined,
+			model: {
+				...backing?.model,
+				id: entry.model_id,
+				tags: featuredTags.length > 0 ? featuredTags : (backing?.model?.tags ?? [])
+			}
+		};
+	};
 
 	let ollamaVersion = null;
 	let selectedModelIdx = 0;
@@ -400,7 +447,8 @@
 	onOpenChange={async () => {
 		searchValue = '';
 		const isFeaturedSelected = featuredModels.some((m) => m.model_id === value);
-		selectedConnectionType = (isFeaturedSelected || (!value && featuredModels.length > 0)) ? 'featured' : '';
+		selectedConnectionType =
+			isFeaturedSelected || (!value && featuredModels.length > 0) ? 'featured' : '';
 		window.setTimeout(() => document.getElementById('model-search-input')?.focus(), 0);
 		resetView();
 	}}
@@ -414,10 +462,7 @@
 		id="model-selector-{id}-button"
 	>
 		<div
-			class="flex w-full text-left px-0.5 bg-transparent truncate {triggerClassName} justify-between {($settings?.highContrastMode ??
-			false)
-				? 'dark:placeholder-gray-100 placeholder-gray-800'
-				: 'placeholder-gray-400'}"
+			class="flex w-full items-center justify-between gap-2 px-3 py-2 rounded-hg-md border border-hg-border-subtle dark:border-gray-800 bg-transparent text-left truncate {triggerClassName}"
 			role="presentation"
 			on:mouseenter={async () => {
 				models.set(
@@ -428,19 +473,27 @@
 				);
 			}}
 		>
-			{#if selectedModel}
-				{selectedModel.label}
-			{:else}
-				{placeholder}
-			{/if}
-			<ChevronDown className=" self-center ml-2 size-3" strokeWidth="2.5" />
+			<div class="flex items-center gap-2 min-w-0">
+				{#if selectedModel}
+					<img
+						src={`${WEBUI_API_BASE_URL}/models/model/profile/image?id=${selectedModel.value}&theme=${resolvedTheme}&lang=${$i18n.language}`}
+						alt=""
+						class="size-5 rounded-full shrink-0"
+						loading="lazy"
+					/>
+					<span class="font-hg-body font-semibold text-base truncate">
+						<span class="text-hg-text-primary dark:text-gray-100">{selectedNameHead}</span>{#if selectedNameTail}<span class="text-hg-text-tertiary dark:text-gray-500">{' '}– {selectedNameTail}</span>{/if}
+					</span>
+				{:else}
+					<span class="font-hg-body text-hg-text-tertiary dark:text-gray-400 truncate">{placeholder}</span>
+				{/if}
+			</div>
+			<HgIconChevronRight class="shrink-0 size-5 text-hg-orange dark:text-gray-400 rotate-90" />
 		</div>
 	</DropdownMenu.Trigger>
 
 	<DropdownMenu.Content
-		class=" z-40 {$mobile
-			? `w-full`
-			: `${className}`} max-w-[calc(100vw-1rem)] justify-start rounded-2xl  bg-white dark:bg-gray-850 dark:text-white shadow-lg  outline-hidden"
+		class="z-40 {$mobile ? 'w-full' : 'w-[400px]'} max-w-[calc(100vw-1rem)] rounded-2xl bg-white dark:bg-gray-850 dark:text-white border border-hg-border-subtle dark:border-gray-800 shadow-lg outline-hidden overflow-hidden"
 		transition={flyAndScale}
 		side={$mobile ? 'bottom' : 'bottom-start'}
 		sideOffset={2}
@@ -448,189 +501,159 @@
 	>
 		<slot>
 			{#if searchEnabled}
-				<div class="flex items-center gap-2.5 px-4.5 mt-3.5 mb-1.5">
-					<Search className="size-4" strokeWidth="2.5" />
+				<div class="p-3 border-b border-hg-border-subtle dark:border-gray-800">
+					<div class="flex items-center gap-2 h-[44px] px-2 rounded-hg-md border border-hg-border dark:border-gray-700 bg-hg-bg-surface dark:bg-gray-900">
+						<Search className="size-5 shrink-0 text-hg-text-tertiary dark:text-gray-500" strokeWidth="2" />
+						<input
+							id="model-search-input"
+							bind:value={searchValue}
+							class="flex-1 text-sm bg-transparent outline-hidden text-hg-text-primary dark:text-gray-100 placeholder:text-hg-text-tertiary dark:placeholder:text-gray-500"
+							placeholder={searchPlaceholder}
+							autocomplete="off"
+							aria-label={$i18n.t('Search In Models')}
+							on:keydown={(e) => {
+								const isFeatured = selectedConnectionType === 'featured';
+								const activeList = isFeatured ? featuredModels : filteredItems;
+								if (e.code === 'Enter' && activeList.length > 0) {
+									value = isFeatured
+										? featuredModels[selectedModelIdx].model_id
+										: filteredItems[selectedModelIdx].value;
+									show = false;
+									return;
+								} else if (e.code === 'ArrowDown') {
+									e.stopPropagation();
+									selectedModelIdx = Math.min(selectedModelIdx + 1, activeList.length - 1);
+								} else if (e.code === 'ArrowUp') {
+									e.stopPropagation();
+									selectedModelIdx = Math.max(selectedModelIdx - 1, 0);
+								} else {
+									selectedModelIdx = 0;
+								}
 
-					<input
-						id="model-search-input"
-						bind:value={searchValue}
-						class="w-full text-sm bg-transparent outline-hidden"
-						placeholder={searchPlaceholder}
-						autocomplete="off"
-						aria-label={$i18n.t('Search In Models')}
-						on:keydown={(e) => {
-							const isFeatured = selectedConnectionType === 'featured';
-							const activeList = isFeatured ? featuredModels : filteredItems;
-							if (e.code === 'Enter' && activeList.length > 0) {
-								value = isFeatured
-									? featuredModels[selectedModelIdx].model_id
-									: filteredItems[selectedModelIdx].value;
-								show = false;
-								return; // dont need to scroll on selection
-							} else if (e.code === 'ArrowDown') {
-								e.stopPropagation();
-								selectedModelIdx = Math.min(selectedModelIdx + 1, activeList.length - 1);
-							} else if (e.code === 'ArrowUp') {
-								e.stopPropagation();
-								selectedModelIdx = Math.max(selectedModelIdx - 1, 0);
-							} else {
-								// if the user types something, reset to the top selection.
-								selectedModelIdx = 0;
-							}
-
-							const item = document.querySelector(`[data-arrow-selected="true"]`);
-							item?.scrollIntoView({ block: 'center', inline: 'nearest', behavior: 'instant' });
-						}}
-					/>
+								const item = document.querySelector(`[data-arrow-selected="true"]`);
+								item?.scrollIntoView({ block: 'center', inline: 'nearest', behavior: 'instant' });
+							}}
+						/>
+					</div>
 				</div>
 			{/if}
 
-			<div class="px-2">
-				{#if tags && items.filter((item) => !(item.model?.info?.meta?.hidden ?? false)).length > 0}
-					<div
-						class=" flex w-full bg-white dark:bg-gray-850 overflow-x-auto scrollbar-none font-[450] mb-0.5"
-						on:wheel={(e) => {
-							if (e.deltaY !== 0) {
-								e.preventDefault();
-								e.currentTarget.scrollLeft += e.deltaY;
-							}
-						}}
-					>
-						<div
-							class="flex gap-1 w-fit text-center text-sm rounded-full bg-transparent px-1.5 whitespace-nowrap"
-							bind:this={tagsContainerElement}
-						>
-							{#if featuredModels.length > 0 && !searchValue}
-								<button
-									class="min-w-fit outline-none px-1.5 py-0.5 {selectedConnectionType === 'featured'
-										? ''
-										: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition capitalize"
-									aria-pressed={selectedConnectionType === 'featured'}
-									on:click={() => {
-										selectedTag = '';
-										selectedConnectionType = 'featured';
-									}}
-								>
-									{$i18n.t('Featured')}
-								</button>
-							{/if}
+			{#if tags && items.filter((item) => !(item.model?.info?.meta?.hidden ?? false)).length > 0}
+				<div
+					class="flex gap-1 p-3 border-b border-hg-border-subtle dark:border-gray-800 overflow-x-auto scrollbar-none"
+					on:wheel={(e) => {
+						if (e.deltaY !== 0) {
+							e.preventDefault();
+							e.currentTarget.scrollLeft += e.deltaY;
+						}
+					}}
+				>
+					<div class="flex gap-1 w-fit whitespace-nowrap" bind:this={tagsContainerElement}>
+						{#if featuredModels.length > 0 && !searchValue}
+							<button
+								class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedConnectionType === 'featured' ? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900' : 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
+								aria-pressed={selectedConnectionType === 'featured'}
+								on:click={() => {
+									selectedTag = '';
+									selectedConnectionType = 'featured';
+								}}
+							>
+								{$i18n.t('Featured')}
+							</button>
+						{/if}
 
-							{#if items.find((item) => item.model?.connection_type === 'local') || items.find((item) => item.model?.connection_type === 'external') || items.find((item) => item.model?.direct) || tags.length > 0}
+						{#if items.find((item) => item.model?.connection_type === 'local') || items.find((item) => item.model?.connection_type === 'external') || items.find((item) => item.model?.direct) || tags.length > 0}
+							<button
+								class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedTag === '' && selectedConnectionType === '' ? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900' : 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
+								aria-pressed={selectedTag === '' && selectedConnectionType === ''}
+								on:click={() => {
+									selectedConnectionType = '';
+									selectedTag = '';
+								}}
+							>
+								{$i18n.t('All')}
+							</button>
+						{/if}
+
+						{#if items.find((item) => item.model?.connection_type === 'local')}
+							<button
+								class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedConnectionType === 'local' ? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900' : 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
+								aria-pressed={selectedConnectionType === 'local'}
+								on:click={() => {
+									selectedTag = '';
+									selectedConnectionType = 'local';
+								}}
+							>
+								{$i18n.t('Local')}
+							</button>
+						{/if}
+
+						<!-- External tab hidden intentionally — all OpenAI-compatible models are "external" by default,
+						     making this tab redundant noise. Re-enable by removing the `false &&` guard below. -->
+						{#if false && items.find((item) => item.model?.connection_type === 'external')}
+							<button
+								class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedConnectionType === 'external' ? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900' : 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
+								aria-pressed={selectedConnectionType === 'external'}
+								on:click={() => {
+									selectedTag = '';
+									selectedConnectionType = 'external';
+								}}
+							>
+								{$i18n.t('External')}
+							</button>
+						{/if}
+
+						{#if items.find((item) => item.model?.direct)}
+							<button
+								class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedConnectionType === 'direct' ? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900' : 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
+								aria-pressed={selectedConnectionType === 'direct'}
+								on:click={() => {
+									selectedTag = '';
+									selectedConnectionType = 'direct';
+								}}
+							>
+								{$i18n.t('Direct')}
+							</button>
+						{/if}
+
+						{#each tags as tag}
+							<Tooltip content={tag}>
 								<button
-									class="min-w-fit outline-none px-1.5 py-0.5 {selectedTag === '' &&
-									selectedConnectionType === ''
-										? ''
-										: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition capitalize"
-									aria-pressed={selectedTag === '' && selectedConnectionType === ''}
+									class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedTag === tag ? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900' : 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
+									aria-pressed={selectedTag === tag}
 									on:click={() => {
 										selectedConnectionType = '';
-										selectedTag = '';
+										selectedTag = tag;
 									}}
 								>
-									{$i18n.t('All')}
+									{tag.length > 16 ? `${tag.slice(0, 16)}...` : tag}
 								</button>
-							{/if}
-
-							{#if items.find((item) => item.model?.connection_type === 'local')}
-								<button
-									class="min-w-fit outline-none px-1.5 py-0.5 {selectedConnectionType === 'local'
-										? ''
-										: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition capitalize"
-									aria-pressed={selectedConnectionType === 'local'}
-									on:click={() => {
-										selectedTag = '';
-										selectedConnectionType = 'local';
-									}}
-								>
-									{$i18n.t('Local')}
-								</button>
-							{/if}
-
-							<!-- External tab hidden intentionally — all OpenAI-compatible models are "external" by default,
-							     making this tab redundant noise. Re-enable by removing the `false &&` guard below. -->
-							{#if false && items.find((item) => item.model?.connection_type === 'external')}
-								<button
-									class="min-w-fit outline-none px-1.5 py-0.5 {selectedConnectionType === 'external'
-										? ''
-										: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition capitalize"
-									aria-pressed={selectedConnectionType === 'external'}
-									on:click={() => {
-										selectedTag = '';
-										selectedConnectionType = 'external';
-									}}
-								>
-									{$i18n.t('External')}
-								</button>
-							{/if}
-
-							{#if items.find((item) => item.model?.direct)}
-								<button
-									class="min-w-fit outline-none px-1.5 py-0.5 {selectedConnectionType === 'direct'
-										? ''
-										: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition capitalize"
-									aria-pressed={selectedConnectionType === 'direct'}
-									on:click={() => {
-										selectedTag = '';
-										selectedConnectionType = 'direct';
-									}}
-								>
-									{$i18n.t('Direct')}
-								</button>
-							{/if}
-
-							{#each tags as tag}
-								<Tooltip content={tag}>
-									<button
-										class="min-w-fit outline-none px-1.5 py-0.5 {selectedTag === tag
-											? ''
-											: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition capitalize"
-										aria-pressed={selectedTag === tag}
-										on:click={() => {
-											selectedConnectionType = '';
-											selectedTag = tag;
-										}}
-									>
-										{tag.length > 16 ? `${tag.slice(0, 16)}...` : tag}
-									</button>
-								</Tooltip>
-							{/each}
-						</div>
+							</Tooltip>
+						{/each}
 					</div>
-				{/if}
+				</div>
+			{/if}
+
+			<div class="px-3 pt-3 pb-2">
+				<p class="text-sm text-hg-text-tertiary dark:text-gray-500">{$i18n.t('AI Models')}</p>
 			</div>
 
-			<div class="px-2.5 max-h-64 overflow-y-auto group relative">
+			<div class="max-h-64 overflow-y-auto group relative">
 				{#if selectedConnectionType === 'featured'}
 					{#each featuredModels as entry, index (entry.model_id)}
-						<button
-							data-arrow-selected={selectedModelIdx === index ? 'true' : undefined}
-							class="flex w-full items-start gap-3 rounded-xl px-3 py-2.5 text-left transition hover:bg-gray-100 dark:hover:bg-gray-800 {value === entry.model_id ? 'bg-gray-100 dark:bg-gray-800' : ''}"
-							on:click={() => {
+						<ModelItem
+							{selectedModelIdx}
+							item={featuredToItem(entry)}
+							{index}
+							{value}
+							{pinModelHandler}
+							{unloadModelHandler}
+							onClick={() => {
 								value = entry.model_id;
+								selectedModelIdx = index;
 								show = false;
 							}}
-						>
-							<div class="flex-1 min-w-0">
-								<div class="flex items-center justify-between gap-2">
-									<span class="font-semibold text-sm text-gray-800 dark:text-gray-100 truncate">{entry.featured_name}</span>
-									{#if value === entry.model_id}
-										<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-4 shrink-0 text-gray-700 dark:text-gray-300">
-											<path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd" />
-										</svg>
-									{/if}
-								</div>
-								{#if entry.provider_name}
-									<div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{entry.provider_name}</div>
-								{/if}
-								{#if entry.tags?.some((t) => t)}
-									<div class="flex flex-wrap gap-1 mt-1.5">
-										{#each entry.tags.filter((t) => t) as tag}
-											<span class="text-xs px-1.5 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">{tag}</span>
-										{/each}
-									</div>
-								{/if}
-							</div>
-						</button>
+						/>
 					{:else}
 						<div class="block px-3 py-2 text-sm text-gray-700 dark:text-gray-100">
 							{$i18n.t('No featured models available')}
@@ -744,10 +767,24 @@
 				{/each}
 			</div>
 
-			<div class="mb-2.5"></div>
-
-			<div class="hidden w-[42rem]"></div>
-			<div class="hidden w-[32rem]"></div>
+			<div class="border-t border-hg-border-subtle dark:border-gray-800 p-3">
+				<button
+					class="flex items-start gap-2 w-full text-left"
+					on:click={toggleDefaultModel}
+					aria-pressed={isCurrentModelDefault}
+				>
+					<div class="mt-0.5 size-4 rounded-[4px] border border-hg-text-tertiary dark:border-gray-500 flex items-center justify-center shrink-0">
+						{#if isCurrentModelDefault}
+							<svg viewBox="0 0 12 12" class="size-3 text-hg-text-primary dark:text-gray-100" fill="none">
+								<path d="M2 6l3 3 5-5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+							</svg>
+						{/if}
+					</div>
+					<span class="text-sm font-semibold font-hg-body text-hg-text-primary dark:text-gray-100">
+						{$i18n.t('Set as default model')}
+					</span>
+				</button>
+			</div>
 		</slot>
 	</DropdownMenu.Content>
 </DropdownMenu.Root>

--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -12,18 +12,10 @@
 
 	import { deleteModel, getOllamaVersion, pullModel, unloadModel } from '$lib/apis/ollama';
 
-	import {
-		user,
-		MODEL_DOWNLOAD_POOL,
-		models,
-		mobile,
-		temporaryChatEnabled,
-		settings,
-		config,
-		theme
-	} from '$lib/stores';
+	import { user, MODEL_DOWNLOAD_POOL, models, mobile, settings, config, theme } from '$lib/stores';
+	import type { Model } from '$lib/stores';
 	import { toast } from 'svelte-sonner';
-	import { capitalizeFirstLetter, sanitizeResponseContent, splitStream } from '$lib/utils';
+	import { splitStream } from '$lib/utils';
 	import { resolveTheme } from '$lib/utils/theme';
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
 	import { getModels } from '$lib/apis';
@@ -62,8 +54,8 @@
 	let show = false;
 	let tags = [];
 
-	let selectedModel = '';
-	$: selectedModel = items.find((item) => item.value === value) ?? '';
+	let selectedModel: (typeof items)[number] | null = null;
+	$: selectedModel = items.find((item) => item.value === value) ?? null;
 
 	$: resolvedTheme = resolveTheme($theme);
 
@@ -81,9 +73,10 @@
 		return spaceIdx === -1 ? '' : label.slice(spaceIdx + 1).trim();
 	})();
 
-	$: isCurrentModelDefault = ($settings?.models?.[0] ?? '') === value;
+	$: isCurrentModelDefault = !!value && ($settings?.models?.[0] ?? '') === value;
 
 	const toggleDefaultModel = async () => {
+		if (!value) return;
 		const newDefault = isCurrentModelDefault ? '' : value;
 		await settings.set({ ...$settings, models: newDefault ? [newDefault] : [] });
 		await updateUserSettings(localStorage.token, { ui: $settings });
@@ -482,10 +475,15 @@
 						loading="lazy"
 					/>
 					<span class="font-hg-body font-semibold text-base truncate">
-						<span class="text-hg-text-primary dark:text-gray-100">{selectedNameHead}</span>{#if selectedNameTail}<span class="text-hg-text-tertiary dark:text-gray-500">{' '}– {selectedNameTail}</span>{/if}
+						<span class="text-hg-text-primary dark:text-gray-100">{selectedNameHead}</span
+						>{#if selectedNameTail}<span class="text-hg-text-tertiary dark:text-gray-500"
+								>{' '}– {selectedNameTail}</span
+							>{/if}
 					</span>
 				{:else}
-					<span class="font-hg-body text-hg-text-tertiary dark:text-gray-400 truncate">{placeholder}</span>
+					<span class="font-hg-body text-hg-text-tertiary dark:text-gray-400 truncate"
+						>{placeholder}</span
+					>
 				{/if}
 			</div>
 			<HgIconChevronRight class="shrink-0 size-5 text-hg-orange dark:text-gray-400 rotate-90" />
@@ -493,7 +491,9 @@
 	</DropdownMenu.Trigger>
 
 	<DropdownMenu.Content
-		class="z-40 {$mobile ? 'w-full' : 'w-[400px]'} max-w-[calc(100vw-1rem)] rounded-2xl bg-white dark:bg-gray-850 dark:text-white border border-hg-border-subtle dark:border-gray-800 shadow-lg outline-hidden overflow-hidden"
+		class="z-40 {$mobile
+			? 'w-full'
+			: 'w-[400px]'} max-w-[calc(100vw-1rem)] rounded-2xl bg-white dark:bg-gray-850 dark:text-white border border-hg-border-subtle dark:border-gray-800 shadow-lg outline-hidden overflow-hidden"
 		transition={flyAndScale}
 		side={$mobile ? 'bottom' : 'bottom-start'}
 		sideOffset={2}
@@ -502,8 +502,13 @@
 		<slot>
 			{#if searchEnabled}
 				<div class="p-3 border-b border-hg-border-subtle dark:border-gray-800">
-					<div class="flex items-center gap-2 h-[44px] px-2 rounded-hg-md border border-hg-border dark:border-gray-700 bg-hg-bg-surface dark:bg-gray-900">
-						<Search className="size-5 shrink-0 text-hg-text-tertiary dark:text-gray-500" strokeWidth="2" />
+					<div
+						class="flex items-center gap-2 h-[44px] px-2 rounded-hg-md border border-hg-border dark:border-gray-700 bg-hg-bg-surface dark:bg-gray-900"
+					>
+						<Search
+							className="size-5 shrink-0 text-hg-text-tertiary dark:text-gray-500"
+							strokeWidth="2"
+						/>
 						<input
 							id="model-search-input"
 							bind:value={searchValue}
@@ -551,7 +556,10 @@
 					<div class="flex gap-1 w-fit whitespace-nowrap" bind:this={tagsContainerElement}>
 						{#if featuredModels.length > 0 && !searchValue}
 							<button
-								class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedConnectionType === 'featured' ? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900' : 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
+								class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedConnectionType ===
+								'featured'
+									? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900'
+									: 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
 								aria-pressed={selectedConnectionType === 'featured'}
 								on:click={() => {
 									selectedTag = '';
@@ -564,7 +572,10 @@
 
 						{#if items.find((item) => item.model?.connection_type === 'local') || items.find((item) => item.model?.connection_type === 'external') || items.find((item) => item.model?.direct) || tags.length > 0}
 							<button
-								class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedTag === '' && selectedConnectionType === '' ? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900' : 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
+								class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedTag ===
+									'' && selectedConnectionType === ''
+									? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900'
+									: 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
 								aria-pressed={selectedTag === '' && selectedConnectionType === ''}
 								on:click={() => {
 									selectedConnectionType = '';
@@ -577,7 +588,10 @@
 
 						{#if items.find((item) => item.model?.connection_type === 'local')}
 							<button
-								class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedConnectionType === 'local' ? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900' : 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
+								class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedConnectionType ===
+								'local'
+									? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900'
+									: 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
 								aria-pressed={selectedConnectionType === 'local'}
 								on:click={() => {
 									selectedTag = '';
@@ -592,7 +606,10 @@
 						     making this tab redundant noise. Re-enable by removing the `false &&` guard below. -->
 						{#if false && items.find((item) => item.model?.connection_type === 'external')}
 							<button
-								class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedConnectionType === 'external' ? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900' : 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
+								class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedConnectionType ===
+								'external'
+									? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900'
+									: 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
 								aria-pressed={selectedConnectionType === 'external'}
 								on:click={() => {
 									selectedTag = '';
@@ -605,7 +622,10 @@
 
 						{#if items.find((item) => item.model?.direct)}
 							<button
-								class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedConnectionType === 'direct' ? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900' : 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
+								class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedConnectionType ===
+								'direct'
+									? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900'
+									: 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
 								aria-pressed={selectedConnectionType === 'direct'}
 								on:click={() => {
 									selectedTag = '';
@@ -619,7 +639,10 @@
 						{#each tags as tag}
 							<Tooltip content={tag}>
 								<button
-									class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedTag === tag ? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900' : 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
+									class="shrink-0 h-8 px-3 rounded-full text-xs font-hg-body outline-none transition capitalize {selectedTag ===
+									tag
+										? 'bg-hg-text-primary dark:bg-gray-100 text-white dark:text-gray-900'
+										: 'bg-hg-bg-muted dark:bg-gray-800 border border-hg-border dark:border-gray-700 text-hg-text-tertiary dark:text-gray-400 hover:text-hg-text-primary dark:hover:text-gray-100'}"
 									aria-pressed={selectedTag === tag}
 									on:click={() => {
 										selectedConnectionType = '';
@@ -773,10 +796,22 @@
 					on:click={toggleDefaultModel}
 					aria-pressed={isCurrentModelDefault}
 				>
-					<div class="mt-0.5 size-4 rounded-[4px] border border-hg-text-tertiary dark:border-gray-500 flex items-center justify-center shrink-0">
+					<div
+						class="mt-0.5 size-4 rounded-[4px] border border-hg-text-tertiary dark:border-gray-500 flex items-center justify-center shrink-0"
+					>
 						{#if isCurrentModelDefault}
-							<svg viewBox="0 0 12 12" class="size-3 text-hg-text-primary dark:text-gray-100" fill="none">
-								<path d="M2 6l3 3 5-5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+							<svg
+								viewBox="0 0 12 12"
+								class="size-3 text-hg-text-primary dark:text-gray-100"
+								fill="none"
+							>
+								<path
+									d="M2 6l3 3 5-5"
+									stroke="currentColor"
+									stroke-width="1.5"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+								/>
 							</svg>
 						{/if}
 					</div>

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -164,8 +164,8 @@ type OllamaModelDetails = {
 };
 
 type Settings = {
-	pinnedModels?: never[];
-	toolServers?: never[];
+	pinnedModels?: string[];
+	toolServers?: { url: string }[];
 	detectArtifacts?: boolean;
 	showUpdateToast?: boolean;
 	showChangelog?: boolean;


### PR DESCRIPTION
Closes: [TRAU-486](https://keepersolutions.atlassian.net/browse/TRAU-486)

### Changes
- Fix pinnedModels type
- Add model selector - closed and open state
- Add HgIconPlus to selector
- Add two-row layout to ModelItem

<img width="884" height="619" alt="Screenshot 2026-06-10 at 16 41 15" src="https://github.com/user-attachments/assets/0b360e28-5629-460e-80c2-9a167d6cb01e" />


Local models usually have `owned_by: "ollama"` property so, in order to evade situations like **Ollama - Gemma3:1b** in the UI when Gemma is served locally, the models will have their names only. This problem can be resolved with the respective providers if the models, when becoming available, go through a form of sorts where admins would fill in the provider brand if the names do not get caught in regex patterns available on` /admin/settings/providers` route in the app

Models on Featured tab can have providers because the component has form field that captures that info as user input.
