### PR TITLE
STAGING: feature/TRAU-511

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,7 +8,9 @@ LANGFUSE_HOST=""
 BILLING_ENABLED=true
 STRIPE_SECRET_KEY=""
 STRIPE_WEBHOOK_SECRET=""
-STRIPE_PRICE_ID=price_dassad
+STRIPE_PRICE_ID=price_item        # legacy alias — treated as pro price ID if STRIPE_PRICE_ID_PRO is unset
+STRIPE_PRICE_ID_PRO=               # Stripe price ID for the Pro plan (overrides STRIPE_PRICE_ID)
+STRIPE_PRICE_ID_PREMIUM=           # Stripe price ID for the Premium plan
 STRIPE_FREE_TIER_CENTS=500
 WEBUI_URL=http://localhost:5173
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -60,3 +60,11 @@ ENABLE_TRUSTMINDER_FEEDBACK=false
 
 # How many days of Langfuse history to import on first deploy when usage_ledger is empty. Ignored after first sync — DB watermark takes over.
 LEDGER_BOOTSTRAP_DAYS=30
+
+# Credits conversion rate: how many credits equal 1 euro cent of Langfuse cost.
+# REQUIRED when BILLING_ENABLED=true — missing value crashes on startup.
+# Locked into each user's row at plan assignment; changing this only affects new signups and renewals.
+CREDITS_PER_EUR_CENT=1.82
+
+#Interval for syncing cost; 300 seconds is a fallback if the value is not provided
+LEDGER_POLL_INTERVAL=30

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -965,7 +965,9 @@ EXTERNAL_PWA_MANIFEST_URL = os.environ.get("EXTERNAL_PWA_MANIFEST_URL")
 BILLING_ENABLED = os.environ.get("BILLING_ENABLED", "false").lower() == "true"
 STRIPE_SECRET_KEY = os.environ.get("STRIPE_SECRET_KEY", "")
 STRIPE_WEBHOOK_SECRET = os.environ.get("STRIPE_WEBHOOK_SECRET", "")
-STRIPE_PRICE_ID = os.environ.get("STRIPE_PRICE_ID", "")  # €45/month flat subscription price
+STRIPE_PRICE_ID = os.environ.get("STRIPE_PRICE_ID", "")  # legacy alias — maps to pro
+STRIPE_PRICE_ID_PRO = os.environ.get("STRIPE_PRICE_ID_PRO", "") or os.environ.get("STRIPE_PRICE_ID", "")
+STRIPE_PRICE_ID_PREMIUM = os.environ.get("STRIPE_PRICE_ID_PREMIUM", "")
 STRIPE_FREE_TIER_CENTS = int(os.environ.get("STRIPE_FREE_TIER_CENTS", "200"))  # €2.00 trial credit
 BILLING_GRACE_PERIOD_DAYS = int(os.environ.get("BILLING_GRACE_PERIOD_DAYS", "3"))
 

--- a/backend/open_webui/langfuse/observations.py
+++ b/backend/open_webui/langfuse/observations.py
@@ -12,7 +12,7 @@ from open_webui.langfuse.metrics import auth_header, load_env
 log = logging.getLogger(__name__)
 
 _PAGE_SIZE = 100
-_TRACE_RESOLVE_WORKERS = 20
+_TRACE_RESOLVE_WORKERS = 10
 _trace_user_cache: TTLCache[str, str] = TTLCache(maxsize=10_000, ttl=7200)
 
 
@@ -88,7 +88,10 @@ def fetch_observations_since(since: dt.datetime) -> Generator[Dict[str, Any], No
                     timeout=30,
                 )
                 if resp.status_code == 429:
-                    wait = int(resp.headers.get("Retry-After", "60"))
+                    try:
+                        wait = int(resp.headers.get("Retry-After", "60"))
+                    except (ValueError, TypeError):
+                        wait = 60
                     log.warning("Langfuse rate limit hit (page %d), retrying in %ds", page, wait)
                     time.sleep(wait)
                     continue

--- a/backend/open_webui/langfuse/observations.py
+++ b/backend/open_webui/langfuse/observations.py
@@ -1,9 +1,11 @@
 import datetime as dt
 import logging
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Generator, Dict, Any, List
 
 import requests
+from cachetools import TTLCache
 
 from open_webui.langfuse.metrics import auth_header, load_env
 
@@ -11,6 +13,7 @@ log = logging.getLogger(__name__)
 
 _PAGE_SIZE = 100
 _TRACE_RESOLVE_WORKERS = 20
+_trace_user_cache: TTLCache[str, str] = TTLCache(maxsize=10_000, ttl=7200)
 
 
 def _fetch_one_trace(host: str, headers: dict, tid: str) -> tuple[str, str]:
@@ -31,14 +34,29 @@ def _fetch_one_trace(host: str, headers: dict, tid: str) -> tuple[str, str]:
 def _resolve_user_ids(
     host: str, headers: dict, trace_ids: List[str], pool: ThreadPoolExecutor
 ) -> Dict[str, str]:
-    """Return {traceId: userId} for a batch of trace IDs, fetched concurrently via shared pool."""
+    """Return {traceId: userId} for a batch of trace IDs.
+
+    Cache hits are returned immediately; only uncached IDs are fetched from Langfuse.
+    Resolved IDs are stored in _trace_user_cache (2h TTL, 10k cap) to reduce API calls
+    across successive poller ticks.
+    """
     if not trace_ids:
         return {}
     result: Dict[str, str] = {}
-    futures = {pool.submit(_fetch_one_trace, host, headers, tid): tid for tid in trace_ids}
-    for future in as_completed(futures):
-        tid, user_id = future.result()
-        result[tid] = user_id
+    to_fetch: List[str] = []
+    for tid in trace_ids:
+        if tid in _trace_user_cache:
+            result[tid] = _trace_user_cache[tid]
+        else:
+            to_fetch.append(tid)
+
+    if to_fetch:
+        futures = {pool.submit(_fetch_one_trace, host, headers, tid): tid for tid in to_fetch}
+        for future in as_completed(futures):
+            tid, user_id = future.result()
+            _trace_user_cache[tid] = user_id
+            result[tid] = user_id
+
     return result
 
 
@@ -69,6 +87,11 @@ def fetch_observations_since(since: dt.datetime) -> Generator[Dict[str, Any], No
                     },
                     timeout=30,
                 )
+                if resp.status_code == 429:
+                    wait = int(resp.headers.get("Retry-After", "60"))
+                    log.warning("Langfuse rate limit hit (page %d), retrying in %ds", page, wait)
+                    time.sleep(wait)
+                    continue
                 resp.raise_for_status()
                 body = resp.json()
             except Exception as exc:

--- a/backend/open_webui/migrations/versions/c3d4e5f6a7b8_add_user_credits.py
+++ b/backend/open_webui/migrations/versions/c3d4e5f6a7b8_add_user_credits.py
@@ -1,0 +1,38 @@
+"""Add user_credits table for credits-based billing
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-06-24 00:00:00.000000
+
+Stores per-user credit balance and the conversion rate locked at plan assignment.
+Credits are the user-facing unit (whole numbers) derived from EUR cost.
+credits_per_eur_cent is snapshotted from the global CREDITS_PER_EUR_CENT env var
+at plan purchase time so a rate change only affects new signups/renewals.
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_credits",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("user_id", sa.Text, nullable=False, unique=True),
+        sa.Column("balance", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("credits_per_eur_cent", sa.Float, nullable=False, server_default="1.82"),
+        sa.Column("updated_at", sa.BigInteger, nullable=False),
+    )
+    op.create_index("ix_user_credits_user_id", "user_credits", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_credits_user_id", table_name="user_credits")
+    op.drop_table("user_credits")

--- a/backend/open_webui/migrations/versions/d4e5f6a7b8c9_merge_heads.py
+++ b/backend/open_webui/migrations/versions/d4e5f6a7b8c9_merge_heads.py
@@ -1,0 +1,22 @@
+"""merge heads
+
+Revision ID: d4e5f6a7b8c9
+Revises: a7b8c9d0e1f2, c3d4e5f6a7b8
+Create Date: 2026-06-25 00:00:00.000000
+
+"""
+
+from typing import Union
+
+revision: str = "d4e5f6a7b8c9"
+down_revision: Union[str, tuple, None] = ("a7b8c9d0e1f2", "c3d4e5f6a7b8")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/open_webui/migrations/versions/e5f6a7b8c9d0_rename_paid_to_pro.py
+++ b/backend/open_webui/migrations/versions/e5f6a7b8c9d0_rename_paid_to_pro.py
@@ -18,8 +18,8 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute("UPDATE stripe_billings SET plan_tier = 'pro' WHERE plan_tier = 'paid'")
+    op.execute("UPDATE stripe_billing SET plan_tier = 'pro' WHERE plan_tier = 'paid'")
 
 
 def downgrade() -> None:
-    op.execute("UPDATE stripe_billings SET plan_tier = 'paid' WHERE plan_tier = 'pro'")
+    op.execute("UPDATE stripe_billing SET plan_tier = 'paid' WHERE plan_tier = 'pro'")

--- a/backend/open_webui/migrations/versions/e5f6a7b8c9d0_rename_paid_to_pro.py
+++ b/backend/open_webui/migrations/versions/e5f6a7b8c9d0_rename_paid_to_pro.py
@@ -1,0 +1,25 @@
+"""Rename plan_tier 'paid' to 'pro' in stripe_billings.
+
+All individual subscribers were stored as 'paid' before tier canonicalisation.
+We only have one paid tier today (pro), so the rename is safe and unambiguous.
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-06-25
+"""
+
+from typing import Union
+from alembic import op
+
+revision: str = "e5f6a7b8c9d0"
+down_revision: Union[str, tuple, None] = "d4e5f6a7b8c9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE stripe_billings SET plan_tier = 'pro' WHERE plan_tier = 'paid'")
+
+
+def downgrade() -> None:
+    op.execute("UPDATE stripe_billings SET plan_tier = 'paid' WHERE plan_tier = 'pro'")

--- a/backend/open_webui/migrations/versions/f2a3b4c5d6e7_backfill_user_credits.py
+++ b/backend/open_webui/migrations/versions/f2a3b4c5d6e7_backfill_user_credits.py
@@ -1,0 +1,91 @@
+"""Backfill user_credits for existing stripe_billing rows that have no credit record.
+
+For every stripe_billing row whose plan_tier is in (trial, pro, premium) and that
+has no corresponding user_credits row, insert a row with:
+  - balance = PLAN_CREDITS[plan_tier]   (using the current CREDITS_PER_EUR_CENT rate)
+  - credits_per_eur_cent = current global rate
+
+This is idempotent — rows that already exist are skipped via INSERT OR IGNORE / ON CONFLICT.
+
+Revision ID: f2a3b4c5d6e7
+Revises: e5f6a7b8c9d0
+Create Date: 2026-06-25
+"""
+
+import os
+import time
+import uuid
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "f2a3b4c5d6e7"
+down_revision: Union[str, tuple, None] = "e5f6a7b8c9d0"
+branch_labels = None
+depends_on = None
+
+_CREDITS_TIERS = {"trial", "pro", "premium"}
+
+
+def _get_rate() -> float:
+    val = os.environ.get("CREDITS_PER_EUR_CENT", "1.82")
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return 1.82
+
+
+def _plan_balance(plan_tier: str, rate: float) -> int:
+    if plan_tier == "trial":
+        return round(2.00 * 100 * rate)
+    if plan_tier == "pro":
+        return 1300
+    if plan_tier == "premium":
+        return 3800
+    return 0
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    rate = _get_rate()
+    now = int(time.time())
+
+    # Fetch all stripe_billing rows that need a user_credits row.
+    # LEFT JOIN so we only touch users with no existing record.
+    rows = conn.execute(
+        sa.text(
+            """
+            SELECT sb.user_id, sb.plan_tier
+            FROM stripe_billing sb
+            LEFT JOIN user_credits uc ON uc.user_id = sb.user_id
+            WHERE sb.plan_tier IN ('trial', 'pro', 'premium')
+              AND uc.user_id IS NULL
+
+            """
+        )
+    ).fetchall()
+
+    for user_id, plan_tier in rows:
+        balance = _plan_balance(plan_tier, rate)
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO user_credits (id, user_id, balance, credits_per_eur_cent, updated_at)
+                VALUES (:id, :user_id, :balance, :rate, :updated_at)
+                """
+            ),
+            {
+                "id": str(uuid.uuid4()),
+                "user_id": user_id,
+                "balance": balance,
+                "rate": rate,
+                "updated_at": now,
+            },
+        )
+
+
+def downgrade() -> None:
+    # Remove only rows that were inserted by this migration (those created at the same
+    # second as a batch is indistinguishable, so downgrade is a no-op to avoid data loss).
+    pass

--- a/backend/open_webui/migrations/versions/f2a3b4c5d6e7_backfill_user_credits.py
+++ b/backend/open_webui/migrations/versions/f2a3b4c5d6e7_backfill_user_credits.py
@@ -56,28 +56,29 @@ def upgrade() -> None:
     rows = conn.execute(
         sa.text(
             """
-            SELECT sb.user_id, sb.plan_tier
+            SELECT u.email, sb.plan_tier
             FROM stripe_billing sb
-            LEFT JOIN user_credits uc ON uc.user_id = sb.user_id
+            JOIN "user" u ON u.id = sb.user_id
+            LEFT JOIN user_credits uc ON uc.user_id = u.email
             WHERE sb.plan_tier IN ('trial', 'pro', 'premium')
               AND uc.user_id IS NULL
-
             """
         )
     ).fetchall()
 
-    for user_id, plan_tier in rows:
+    for email, plan_tier in rows:
         balance = _plan_balance(plan_tier, rate)
         conn.execute(
             sa.text(
                 """
                 INSERT INTO user_credits (id, user_id, balance, credits_per_eur_cent, updated_at)
                 VALUES (:id, :user_id, :balance, :rate, :updated_at)
+                ON CONFLICT (user_id) DO NOTHING
                 """
             ),
             {
                 "id": str(uuid.uuid4()),
-                "user_id": user_id,
+                "user_id": email,
                 "balance": balance,
                 "rate": rate,
                 "updated_at": now,

--- a/backend/open_webui/models/billing.py
+++ b/backend/open_webui/models/billing.py
@@ -30,7 +30,7 @@ class StripeBilling(Base):
 
     subscription_status = Column(Text, nullable=True)  # active | past_due | canceled | incomplete
     free_tier_credit_applied = Column(Boolean, default=False, nullable=False)
-    plan_tier = Column(Text, nullable=True)  # internal | trial | paid | team | team_member
+    plan_tier = Column(Text, nullable=True)  # internal | trial | pro | premium | team | team_member
     checkout_session_id = Column(Text, nullable=True)
     team_id = Column(Text, nullable=True)  # set for plan_tier "team" and "team_member"
 
@@ -51,7 +51,7 @@ class StripeBillingModel(BaseModel):
 
     subscription_status: Optional[str] = None
     free_tier_credit_applied: bool = False
-    plan_tier: Optional[str] = None  # internal | trial | paid | team | team_member
+    plan_tier: Optional[str] = None  # internal | trial | pro | premium | team | team_member
     checkout_session_id: Optional[str] = None
     team_id: Optional[str] = None
 

--- a/backend/open_webui/models/billing_plans.py
+++ b/backend/open_webui/models/billing_plans.py
@@ -1,0 +1,25 @@
+"""Single source of truth for plan tier strings and credit allocations.
+
+Import these constants everywhere instead of using raw strings.
+"""
+
+PLAN_TIER_INTERNAL    = "internal"
+PLAN_TIER_TRIAL       = "trial"
+PLAN_TIER_PRO         = "pro"
+PLAN_TIER_PREMIUM     = "premium"
+PLAN_TIER_TEAM        = "team"
+PLAN_TIER_TEAM_MEMBER = "team_member"
+
+# Tiers that use the credits system (balance tracked in user_credits table)
+CREDITS_TIERS: frozenset[str] = frozenset({
+    PLAN_TIER_TRIAL,
+    PLAN_TIER_PRO,
+    PLAN_TIER_PREMIUM,
+})
+
+# Monthly credit allocations per tier.
+# trial is omitted here — it's computed at onboard time from CREDITS_PER_EUR_CENT.
+PLAN_CREDITS: dict[str, int] = {
+    PLAN_TIER_PRO:     1300,
+    PLAN_TIER_PREMIUM: 3800,
+}

--- a/backend/open_webui/models/user_credits.py
+++ b/backend/open_webui/models/user_credits.py
@@ -1,0 +1,118 @@
+import os
+import time
+import uuid
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import BigInteger, Column, Float, Index, Integer, Text
+
+from open_webui.internal.db import Base, get_db
+from open_webui.models.billing_plans import PLAN_CREDITS, PLAN_TIER_TRIAL  # noqa: F401 — re-exported for callers
+
+
+def _load_credits_per_eur_cent() -> float:
+    val = os.environ.get("CREDITS_PER_EUR_CENT")
+    if val is None:
+        raise RuntimeError("CREDITS_PER_EUR_CENT env var is required but not set")
+    return float(val)
+
+
+CREDITS_PER_EUR_CENT: float = _load_credits_per_eur_cent()
+
+# Populate the trial entry now that we have the rate.
+# Pro and premium are fixed; trial converts €2.00 at the current rate.
+PLAN_CREDITS[PLAN_TIER_TRIAL] = round(2.00 * 100 * CREDITS_PER_EUR_CENT)
+
+
+def eur_to_credits(eur: float, rate: float) -> int:
+    return round(eur * 100 * rate)
+
+
+def credits_to_eur(credits: int, rate: float) -> float:
+    return round(credits / (100 * rate), 4) if rate > 0 else 0.0
+
+
+####################
+# UserCredits DB Schema
+####################
+
+
+class UserCredits(Base):
+    __tablename__ = "user_credits"
+
+    id = Column(Text, primary_key=True)
+    user_id = Column(Text, unique=True, nullable=False)
+    balance = Column(Integer, default=0, nullable=False)
+    credits_per_eur_cent = Column(Float, default=1.82, nullable=False)
+    updated_at = Column(BigInteger, nullable=False)
+
+    __table_args__ = (Index("ix_user_credits_user_id", "user_id"),)
+
+
+class UserCreditsModel(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    user_id: str
+    balance: int
+    credits_per_eur_cent: float
+    updated_at: int
+
+
+####################
+# Table accessor
+####################
+
+
+class UserCreditsTable:
+    def get(self, user_id: str) -> Optional[UserCreditsModel]:
+        with get_db() as db:
+            row = db.query(UserCredits).filter_by(user_id=user_id).first()
+            return UserCreditsModel.model_validate(row) if row else None
+
+    def get_balance(self, user_id: str) -> int:
+        row = self.get(user_id)
+        return row.balance if row else 0
+
+    def add_credits(self, user_id: str, amount: int) -> int:
+        """Atomic increment. Does not change credits_per_eur_cent. Returns new balance."""
+        with get_db() as db:
+            row = db.query(UserCredits).filter_by(user_id=user_id).first()
+            if row is None:
+                row = UserCredits(
+                    id=str(uuid.uuid4()),
+                    user_id=user_id,
+                    balance=amount,
+                    credits_per_eur_cent=CREDITS_PER_EUR_CENT,
+                    updated_at=int(time.time()),
+                )
+                db.add(row)
+            else:
+                row.balance += amount
+                row.updated_at = int(time.time())
+            db.commit()
+            db.refresh(row)
+            return row.balance
+
+    def set_plan(self, user_id: str, balance: int, credits_per_eur_cent: float) -> UserCreditsModel:
+        """Upsert — resets balance and locks the rate. Used on plan assignment and monthly renewal."""
+        with get_db() as db:
+            row = db.query(UserCredits).filter_by(user_id=user_id).first()
+            if row is None:
+                row = UserCredits(
+                    id=str(uuid.uuid4()),
+                    user_id=user_id,
+                    balance=balance,
+                    credits_per_eur_cent=credits_per_eur_cent,
+                    updated_at=int(time.time()),
+                )
+                db.add(row)
+            else:
+                row.balance = balance
+                row.credits_per_eur_cent = credits_per_eur_cent
+                row.updated_at = int(time.time())
+            db.commit()
+            db.refresh(row)
+            return UserCreditsModel.model_validate(row)
+
+
+UserCreditsDB = UserCreditsTable()

--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -297,12 +297,11 @@ class UsersTable:
     def get_user_by_email(
         self, email: str, db: Optional[Session] = None
     ) -> Optional[UserModel]:
-        try:
-            with get_db_context(db) as db:
-                user = db.query(User).filter_by(email=email).first()
-                return UserModel.model_validate(user)
-        except Exception:
-            return None
+        with get_db_context(db) as db:
+            user = db.query(User).filter_by(email=email).first()
+            if user is None:
+                return None
+            return UserModel.model_validate(user)
 
     def get_user_by_oauth_sub(
         self, provider: str, sub: str, db: Optional[Session] = None

--- a/backend/open_webui/routers/billing.py
+++ b/backend/open_webui/routers/billing.py
@@ -12,6 +12,8 @@ from open_webui.env import (
     INTERNAL_EMAIL_DOMAINS,
     STRIPE_FREE_TIER_CENTS,
     STRIPE_PRICE_ID,
+    STRIPE_PRICE_ID_PRO,
+    STRIPE_PRICE_ID_PREMIUM,
     STRIPE_SECRET_KEY,
     STRIPE_TEAM_TIERS,
     STRIPE_TOPUP_AMOUNTS,
@@ -19,6 +21,16 @@ from open_webui.env import (
     TRIAL_CREDIT_EUR,
 )
 from open_webui.models.billing import StripeBillings, TeamInvites, TeamMembers, Teams
+from open_webui.models.billing_plans import (
+    CREDITS_TIERS,
+    PLAN_CREDITS,
+    PLAN_TIER_INTERNAL,
+    PLAN_TIER_PREMIUM,
+    PLAN_TIER_PRO,
+    PLAN_TIER_TEAM,
+    PLAN_TIER_TEAM_MEMBER,
+    PLAN_TIER_TRIAL,
+)
 from open_webui.utils.auth import get_admin_user, get_verified_user
 
 log = logging.getLogger(__name__)
@@ -63,6 +75,30 @@ _team_cost_cache: _TTLCache = _TTLCache(maxsize=256, ttl=_TEAM_COST_CACHE_TTL)
 # ---------- Helpers ----------
 
 
+def _tier_from_price_id(price_id: str) -> str:
+    """Map a Stripe price ID to a plan tier string. Defaults to pro for unknown IDs."""
+    if STRIPE_PRICE_ID_PREMIUM and price_id == STRIPE_PRICE_ID_PREMIUM:
+        return PLAN_TIER_PREMIUM
+    return PLAN_TIER_PRO
+
+
+def _price_id_from_session(session) -> str:
+    """Extract the first price ID from a Stripe checkout session object."""
+    try:
+        line_items = getattr(session, "line_items", None)
+        if line_items:
+            data = getattr(line_items, "data", None) or line_items.get("data", [])
+            if data:
+                price = getattr(data[0], "price", None) or data[0].get("price", {})
+                return getattr(price, "id", None) or price.get("id", "")
+    except Exception:
+        pass
+    meta = getattr(session, "metadata", None) or {}
+    if hasattr(meta, "get"):
+        return meta.get("price_id", "")
+    return ""
+
+
 def is_internal_user(email: str) -> bool:
     domain = email.split("@")[-1].lower()
     return domain in INTERNAL_EMAIL_DOMAINS
@@ -104,6 +140,41 @@ def _get_user_current_month_cost(email: str) -> float:
     except Exception as e:
         log.warning(f"Could not fetch monthly ledger cost for {email}: {e}")
         return 0.0
+
+
+def _check_credits_exhausted(email: str) -> None:
+    """Raise 402 with detail='credits_exhausted' if the user has no remaining credits.
+
+    Trial credits are lifetime (alltime cost). Pro/premium reset monthly.
+    When no user_credits row exists, falls back to the plan's default balance so
+    users who raced past onboarding are still enforced (not silently allowed through).
+    """
+    try:
+        from open_webui.models.user_credits import CREDITS_PER_EUR_CENT, UserCreditsDB, eur_to_credits
+
+        record = StripeBillings.get_by_email(email)
+        if not record or record.plan_tier not in CREDITS_TIERS:
+            return
+
+        row = UserCreditsDB.get(email)
+        balance = row.balance if row else PLAN_CREDITS.get(record.plan_tier, 0)
+        rate = row.credits_per_eur_cent if row else CREDITS_PER_EUR_CENT
+
+        if record.plan_tier == PLAN_TIER_TRIAL:
+            cost_eur = _get_user_alltime_cost(email, record.created_at or 0)
+        else:
+            cost_eur = _get_user_current_month_cost(email)
+
+        used = eur_to_credits(cost_eur, rate)
+        if used >= balance:
+            raise HTTPException(
+                status_code=status.HTTP_402_PAYMENT_REQUIRED,
+                detail="credits_exhausted",
+            )
+    except HTTPException:
+        raise
+    except Exception as e:
+        log.warning("[billing] credits exhaustion check failed for %s: %s", email, e)
 
 
 def _get_team_current_month_cost(team_id: str) -> float:
@@ -165,8 +236,9 @@ async def check_billing_access(user=Depends(get_verified_user)):
         if record is None:
             return user  # Stripe unreachable, allow through
 
-    if record.plan_tier == "paid":
+    if record.plan_tier in (PLAN_TIER_PRO, PLAN_TIER_PREMIUM):
         if record.subscription_status in ("active", "trialing"):
+            _check_credits_exhausted(user.email)
             return user
         if record.subscription_status == "canceled":
             raise HTTPException(
@@ -178,7 +250,7 @@ async def check_billing_access(user=Depends(get_verified_user)):
             detail="Your payment is past due. Please update your billing details at /billing.",
         )
 
-    if record.plan_tier == "team":
+    if record.plan_tier == PLAN_TIER_TEAM:
         team = Teams.get_by_owner_user_id(user.id)
         if not team or team.subscription_status not in ("active", "trialing"):
             raise HTTPException(
@@ -198,7 +270,7 @@ async def check_billing_access(user=Depends(get_verified_user)):
                 )
         return user
 
-    if record.plan_tier == "team_member":
+    if record.plan_tier == PLAN_TIER_TEAM_MEMBER:
         if not record.team_id:
             raise HTTPException(
                 status_code=status.HTTP_402_PAYMENT_REQUIRED,
@@ -223,16 +295,8 @@ async def check_billing_access(user=Depends(get_verified_user)):
                 )
         return user
 
-    if record.plan_tier == "trial":
-        cost_used = _get_user_alltime_cost(user.email, record.created_at)
-        if cost_used >= TRIAL_CREDIT_EUR:
-            raise HTTPException(
-                status_code=status.HTTP_402_PAYMENT_REQUIRED,
-                detail=(
-                    f"Your €{TRIAL_CREDIT_EUR:.2f} trial credit has been used up. "
-                    "Please upgrade your plan at /billing."
-                ),
-            )
+    if record.plan_tier == PLAN_TIER_TRIAL:
+        _check_credits_exhausted(user.email)
         return user
 
     # plan_tier is None or "internal" — allow (covers legacy rows and internal users)
@@ -301,7 +365,10 @@ async def auto_onboard_user(user, request=None):
             plan_tier="trial",
             free_tier_credit_applied=free_tier_applied,
         )
-        log.info(f"[billing] External user onboarded as trial: {user.email} (customer={customer_id})")
+        # Assign trial credits at current global rate
+        from open_webui.models.user_credits import UserCreditsDB, CREDITS_PER_EUR_CENT, PLAN_CREDITS
+        UserCreditsDB.set_plan(user.email, PLAN_CREDITS["trial"], CREDITS_PER_EUR_CENT)
+        log.info(f"[billing] External user onboarded as trial: {user.email} (customer={customer_id}, credits={PLAN_CREDITS['trial']})")
 
     except stripe.StripeError as e:
         log.error(f"[billing] Failed to onboard external user {user.email}: {e}")
@@ -1313,15 +1380,24 @@ async def _handle_stripe_event(event_type: str, data):
                 record = StripeBillings.get_by_customer_id(customer_id)
 
             if record:
+                price_id = _price_id_from_session(data)
+                plan_tier = _tier_from_price_id(price_id)
                 StripeBillings.upsert(
                     user_id=record.user_id,
                     stripe_customer_id=customer_id,
                     stripe_subscription_id=subscription_id,
-                    plan_tier="paid",
+                    plan_tier=plan_tier,
                     subscription_status="active",
                     free_tier_credit_applied=record.free_tier_credit_applied,
                 )
-                log.info(f"[billing] Checkout completed: user_id={record.user_id} → paid plan")
+                log.info(f"[billing] Checkout completed: user_id={record.user_id} → {plan_tier}")
+                from open_webui.models.user_credits import CREDITS_PER_EUR_CENT, UserCreditsDB
+                from open_webui.models.users import Users as _Users
+                u = _Users.get_user_by_id(record.user_id)
+                if u:
+                    credits = PLAN_CREDITS.get(plan_tier, PLAN_CREDITS[PLAN_TIER_PRO])
+                    UserCreditsDB.set_plan(u.email, credits, CREDITS_PER_EUR_CENT)
+                    log.info("[billing] Credits assigned: user=%s plan=%s balance=%d rate=%s", u.email, plan_tier, credits, CREDITS_PER_EUR_CENT)
 
     elif event_type in ("customer.subscription.updated", "customer.subscription.deleted"):
         customer_id = getattr(data, "customer", None)
@@ -1351,9 +1427,19 @@ async def _handle_stripe_event(event_type: str, data):
                 log.info(f"[billing] Team payment recovered: customer={customer_id}")
             else:
                 record = StripeBillings.get_by_customer_id(customer_id)
-                if record and record.subscription_status == "past_due":
-                    StripeBillings.update_subscription_status(customer_id, "active")
-                    log.info(f"[billing] Payment recovered: customer={customer_id}")
+                if record:
+                    if record.subscription_status == "past_due":
+                        StripeBillings.update_subscription_status(customer_id, "active")
+                        log.info(f"[billing] Payment recovered: customer={customer_id}")
+                    # Monthly renewal — reset credits at current global rate
+                    if record.plan_tier in (PLAN_TIER_PRO, PLAN_TIER_PREMIUM):
+                        from open_webui.models.user_credits import CREDITS_PER_EUR_CENT, UserCreditsDB
+                        from open_webui.models.users import Users as _Users
+                        u = _Users.get_user_by_id(record.user_id)
+                        if u:
+                            credits = PLAN_CREDITS.get(record.plan_tier, PLAN_CREDITS[PLAN_TIER_PRO])
+                            UserCreditsDB.set_plan(u.email, credits, CREDITS_PER_EUR_CENT)
+                            log.info("[billing] Monthly renewal credits reset: user=%s plan=%s balance=%d rate=%s", u.email, record.plan_tier, credits, CREDITS_PER_EUR_CENT)
 
     elif event_type == "payment_method.attached":
         customer_id = getattr(data, "customer", None)
@@ -1478,6 +1564,10 @@ class MyUsageResponse(BaseModel):
     total_cost_eur: float
     exchange_rates: list[ExchangeRateEntry] = []
     ledger_ready: bool = True
+    credits_balance: int = 0
+    credits_used: int = 0
+    credits_remaining: int = 0
+    credits_per_eur_cent: float = 0.0  # 0 = credits not applicable (internal)
 
 
 @router.get("/my-usage", response_model=MyUsageResponse)
@@ -1486,12 +1576,27 @@ async def get_my_usage(user=Depends(get_verified_user)):
     require_billing_enabled()
 
     from open_webui.models.usage_ledger import UsageLedgerDB
+    from open_webui.models.user_credits import UserCreditsDB, eur_to_credits
 
     cost_eur = UsageLedgerDB.get_cost_eur_for_user_current_month(user.email)
     cost_usd = UsageLedgerDB.get_cost_usd_for_user_current_month(user.email)
     total_tokens = UsageLedgerDB.get_tokens_for_user_current_month(user.email)
     rates = UsageLedgerDB.get_exchange_rates_current_month(user.email)
     now = datetime.datetime.utcnow()
+
+    record = StripeBillings.get_by_user_id(user.id)
+    credits_balance = credits_used = credits_remaining = 0
+    credits_per_eur_cent = 0.0
+
+    if record and record.plan_tier in CREDITS_TIERS:
+        from open_webui.models.user_credits import CREDITS_PER_EUR_CENT
+        row = UserCreditsDB.get(user.email)
+        rate = row.credits_per_eur_cent if row else CREDITS_PER_EUR_CENT
+        balance = row.balance if row else PLAN_CREDITS.get(record.plan_tier, 0)
+        credits_per_eur_cent = rate
+        credits_balance = balance
+        credits_used = eur_to_credits(cost_eur, rate)
+        credits_remaining = max(0, balance - credits_used)
 
     return MyUsageResponse(
         month=now.month,
@@ -1501,4 +1606,8 @@ async def get_my_usage(user=Depends(get_verified_user)):
         total_cost_eur=round(cost_eur, 4),
         exchange_rates=[ExchangeRateEntry(**{"from": r["from"], "to": r["to"], "usd_per_eur": r["usd_per_eur"]}) for r in rates],
         ledger_ready=UsageLedgerDB.is_ledger_ready(),
+        credits_balance=credits_balance,
+        credits_used=credits_used,
+        credits_remaining=credits_remaining,
+        credits_per_eur_cent=credits_per_eur_cent,
     )

--- a/backend/open_webui/routers/billing.py
+++ b/backend/open_webui/routers/billing.py
@@ -142,7 +142,7 @@ def _get_user_current_month_cost(email: str) -> float:
         return 0.0
 
 
-def _check_credits_exhausted(email: str) -> None:
+def _check_credits_exhausted(email: str, user_id: str) -> None:
     """Raise 402 with detail='credits_exhausted' if the user has no remaining credits.
 
     Trial credits are lifetime (alltime cost). Pro/premium reset monthly.
@@ -152,7 +152,7 @@ def _check_credits_exhausted(email: str) -> None:
     try:
         from open_webui.models.user_credits import CREDITS_PER_EUR_CENT, UserCreditsDB, eur_to_credits
 
-        record = StripeBillings.get_by_email(email)
+        record = StripeBillings.get_by_user_id(user_id)
         if not record or record.plan_tier not in CREDITS_TIERS:
             return
 
@@ -238,7 +238,7 @@ async def check_billing_access(user=Depends(get_verified_user)):
 
     if record.plan_tier in (PLAN_TIER_PRO, PLAN_TIER_PREMIUM):
         if record.subscription_status in ("active", "trialing"):
-            _check_credits_exhausted(user.email)
+            _check_credits_exhausted(user.email, user.id)
             return user
         if record.subscription_status == "canceled":
             raise HTTPException(

--- a/backend/open_webui/tasks/billing.py
+++ b/backend/open_webui/tasks/billing.py
@@ -366,4 +366,8 @@ async def periodic_ledger_poller():
         except Exception as exc:
             log.error("[ledger-poller] Unexpected error: %s", exc)
 
-        await asyncio.sleep(int(os.environ.get("LEDGER_POLL_INTERVAL", "300")))
+        try:
+            poll_interval = int(os.environ.get("LEDGER_POLL_INTERVAL", "300"))
+        except (ValueError, TypeError):
+            poll_interval = 300
+        await asyncio.sleep(poll_interval)

--- a/backend/open_webui/tasks/billing.py
+++ b/backend/open_webui/tasks/billing.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import logging
+import os
 import time
 from typing import Set
 
@@ -220,6 +221,28 @@ def _sync_observations(since: datetime.datetime, *, deep_rescan: bool = False) -
 
     log.info("[ledger-poller] Synced %d observations (%d inserted, %d cost-backfilled).", len(rows), inserted, updated)
 
+    # Log overage for credits users — signals potential abuse if repeated across syncs
+    try:
+        from open_webui.models.user_credits import UserCreditsDB, eur_to_credits
+        distinct_users = {r["user_id"] for r in rows if r.get("user_id")}
+        for uid in distinct_users:
+            row_creds = UserCreditsDB.get(uid)
+            if row_creds and row_creds.balance > 0:
+                try:
+                    from open_webui.models.usage_ledger import UsageLedgerDB as _UL
+                    cost = _UL.get_cost_eur_for_user_current_month(uid)
+                except Exception:
+                    continue
+                used = eur_to_credits(cost, row_creds.credits_per_eur_cent)
+                remaining = row_creds.balance - used
+                if remaining < 0:
+                    log.warning(
+                        "[ledger-poller] credits overage: user=%s overshot=%d credits (balance=%d used=%d)",
+                        uid, abs(remaining), row_creds.balance, used,
+                    )
+    except Exception as _e:
+        log.debug("[ledger-poller] overage check skipped: %s", _e)
+
     # Re-arm alert state for models that were "recovered" but have lost pricing again
     relapsed = unpriced_models & _priced_models_recovered
     if relapsed:
@@ -343,4 +366,4 @@ async def periodic_ledger_poller():
         except Exception as exc:
             log.error("[ledger-poller] Unexpected error: %s", exc)
 
-        await asyncio.sleep(300)
+        await asyncio.sleep(int(os.environ.get("LEDGER_POLL_INTERVAL", "300")))

--- a/backend/open_webui/tests/langfuse/test_observations.py
+++ b/backend/open_webui/tests/langfuse/test_observations.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import open_webui.langfuse.observations as obs_module
 from open_webui.langfuse.observations import fetch_observations_since, _resolve_user_ids
 
 
@@ -52,6 +53,13 @@ SINCE = datetime.datetime(2026, 6, 19, 0, 0, 0, tzinfo=datetime.timezone.utc)
 def patch_load_env():
     with patch("open_webui.langfuse.observations.load_env", return_value=("pk", "sk", "https://cloud.langfuse.com")):
         yield
+
+
+@pytest.fixture(autouse=True)
+def clear_trace_cache():
+    obs_module._trace_user_cache.clear()
+    yield
+    obs_module._trace_user_cache.clear()
 
 
 class TestResolveUserIds:
@@ -103,6 +111,39 @@ class TestResolveUserIds:
             with ThreadPoolExecutor(max_workers=1) as pool:
                 result = _resolve_user_ids("https://host", {}, ["trace_aaa"], pool)
         assert result["trace_aaa"] == ""
+
+    def test_cache_miss_fetches_and_stores(self):
+        mock_resp = _make_trace_response("user@example.com")
+        with patch("open_webui.langfuse.observations.requests.get", return_value=mock_resp) as mock_get:
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                result = _resolve_user_ids("https://host", {}, ["trace_aaa"], pool)
+        assert result == {"trace_aaa": "user@example.com"}
+        assert mock_get.call_count == 1
+        assert obs_module._trace_user_cache["trace_aaa"] == "user@example.com"
+
+    def test_cache_hit_skips_fetch(self):
+        obs_module._trace_user_cache["trace_aaa"] = "cached@example.com"
+        with patch("open_webui.langfuse.observations.requests.get") as mock_get:
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                result = _resolve_user_ids("https://host", {}, ["trace_aaa"], pool)
+        assert result == {"trace_aaa": "cached@example.com"}
+        mock_get.assert_not_called()
+
+    def test_cache_partial_hit_only_fetches_misses(self):
+        obs_module._trace_user_cache["trace_aaa"] = "alice@example.com"
+
+        def side_effect(url, **kwargs):
+            if "trace_bbb" in url:
+                return _make_trace_response("bob@example.com")
+            raise ValueError(f"unexpected url: {url}")
+
+        with patch("open_webui.langfuse.observations.requests.get", side_effect=side_effect) as mock_get:
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                result = _resolve_user_ids("https://host", {}, ["trace_aaa", "trace_bbb"], pool)
+
+        assert result["trace_aaa"] == "alice@example.com"
+        assert result["trace_bbb"] == "bob@example.com"
+        assert mock_get.call_count == 1  # only trace_bbb fetched
 
 
 class TestFetchObservationsSince:

--- a/backend/open_webui/tests/models/conftest.py
+++ b/backend/open_webui/tests/models/conftest.py
@@ -1,0 +1,5 @@
+import os
+
+# Set before any test module is imported — CREDITS_PER_EUR_CENT is evaluated at
+# import time in user_credits.py and crashes collection if missing.
+os.environ.setdefault("CREDITS_PER_EUR_CENT", "1.82")

--- a/backend/open_webui/tests/models/test_billing_plans.py
+++ b/backend/open_webui/tests/models/test_billing_plans.py
@@ -1,0 +1,82 @@
+"""Tests for models/billing_plans.py — plan tier constants."""
+import pytest
+from open_webui.models.billing_plans import (
+    PLAN_TIER_INTERNAL,
+    PLAN_TIER_TRIAL,
+    PLAN_TIER_PRO,
+    PLAN_TIER_PREMIUM,
+    PLAN_TIER_TEAM,
+    PLAN_TIER_TEAM_MEMBER,
+    CREDITS_TIERS,
+    PLAN_CREDITS,
+)
+
+
+class TestPlanTierValues:
+    def test_internal(self):
+        assert PLAN_TIER_INTERNAL == "internal"
+
+    def test_trial(self):
+        assert PLAN_TIER_TRIAL == "trial"
+
+    def test_pro(self):
+        assert PLAN_TIER_PRO == "pro"
+
+    def test_premium(self):
+        assert PLAN_TIER_PREMIUM == "premium"
+
+    def test_team(self):
+        assert PLAN_TIER_TEAM == "team"
+
+    def test_team_member(self):
+        assert PLAN_TIER_TEAM_MEMBER == "team_member"
+
+    def test_no_paid_string_exists(self):
+        """The legacy 'paid' tier must not appear anywhere in the constants."""
+        all_tiers = {
+            PLAN_TIER_INTERNAL, PLAN_TIER_TRIAL, PLAN_TIER_PRO,
+            PLAN_TIER_PREMIUM, PLAN_TIER_TEAM, PLAN_TIER_TEAM_MEMBER,
+        }
+        assert "paid" not in all_tiers
+
+
+class TestCreditsTiers:
+    def test_trial_in_credits_tiers(self):
+        assert PLAN_TIER_TRIAL in CREDITS_TIERS
+
+    def test_pro_in_credits_tiers(self):
+        assert PLAN_TIER_PRO in CREDITS_TIERS
+
+    def test_premium_in_credits_tiers(self):
+        assert PLAN_TIER_PREMIUM in CREDITS_TIERS
+
+    def test_internal_not_in_credits_tiers(self):
+        assert PLAN_TIER_INTERNAL not in CREDITS_TIERS
+
+    def test_team_not_in_credits_tiers(self):
+        assert PLAN_TIER_TEAM not in CREDITS_TIERS
+
+    def test_team_member_not_in_credits_tiers(self):
+        assert PLAN_TIER_TEAM_MEMBER not in CREDITS_TIERS
+
+    def test_paid_not_in_credits_tiers(self):
+        assert "paid" not in CREDITS_TIERS
+
+    def test_is_frozenset(self):
+        assert isinstance(CREDITS_TIERS, frozenset)
+
+
+class TestPlanCredits:
+    def test_pro_credits(self):
+        assert PLAN_CREDITS[PLAN_TIER_PRO] == 1300
+
+    def test_premium_credits(self):
+        assert PLAN_CREDITS[PLAN_TIER_PREMIUM] == 3800
+
+    def test_no_paid_key(self):
+        assert "paid" not in PLAN_CREDITS
+
+    def test_all_keys_are_valid_tiers(self):
+        valid = {PLAN_TIER_TRIAL, PLAN_TIER_PRO, PLAN_TIER_PREMIUM}
+        for key in PLAN_CREDITS:
+            assert key in valid, f"Unexpected key in PLAN_CREDITS: {key!r}"

--- a/backend/open_webui/tests/models/test_user_credits.py
+++ b/backend/open_webui/tests/models/test_user_credits.py
@@ -1,0 +1,128 @@
+"""Tests for models/user_credits.py — UserCreditsTable."""
+import time
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from open_webui.models.user_credits import (
+    UserCredits,
+    UserCreditsTable,
+    eur_to_credits,
+    credits_to_eur,
+)
+
+
+@pytest.fixture(scope="module")
+def db_engine():
+    engine = create_engine("sqlite:///:memory:")
+    UserCredits.__table__.create(engine, checkfirst=True)
+    yield engine
+    UserCredits.__table__.drop(engine)
+
+
+@pytest.fixture
+def db_session(db_engine):
+    Session = sessionmaker(bind=db_engine)
+    session = Session()
+    yield session
+    session.rollback()
+    session.query(UserCredits).delete()
+    session.commit()
+    session.close()
+
+
+@pytest.fixture
+def table(db_session):
+    @contextmanager
+    def _get_db():
+        yield db_session
+
+    with patch("open_webui.models.user_credits.get_db", _get_db):
+        yield UserCreditsTable()
+
+
+class TestConversionHelpers:
+    def test_eur_to_credits_standard_rate(self):
+        assert eur_to_credits(1.0, 1.82) == 182
+
+    def test_eur_to_credits_trial(self):
+        assert eur_to_credits(2.0, 1.82) == 364
+
+    def test_eur_to_credits_after_rate_change(self):
+        assert eur_to_credits(1.0, 2.0) == 200
+
+    def test_credits_to_eur_standard_rate(self):
+        assert credits_to_eur(182, 1.82) == 1.0
+
+    def test_credits_to_eur_zero_rate_returns_zero(self):
+        assert credits_to_eur(182, 0.0) == 0.0
+
+
+class TestGetBalance:
+    def test_returns_zero_for_unknown_user(self, table):
+        assert table.get_balance("nobody@example.com") == 0
+
+    def test_get_returns_none_for_unknown_user(self, table):
+        assert table.get("nobody@example.com") is None
+
+
+class TestSetPlan:
+    def test_creates_row_on_first_call(self, table):
+        result = table.set_plan("alice@example.com", 1300, 1.82)
+        assert result.balance == 1300
+        assert result.credits_per_eur_cent == 1.82
+        assert result.user_id == "alice@example.com"
+
+    def test_resets_balance_on_renewal(self, table):
+        table.set_plan("bob@example.com", 3800, 1.82)
+        result = table.set_plan("bob@example.com", 1300, 1.82)
+        assert result.balance == 1300
+
+    def test_locks_new_rate_on_renewal(self, table):
+        table.set_plan("carol@example.com", 1300, 1.82)
+        result = table.set_plan("carol@example.com", 1300, 2.0)
+        assert result.credits_per_eur_cent == 2.0
+
+    def test_no_duplicate_row_on_repeat_calls(self, table, db_session):
+        table.set_plan("dave@example.com", 364, 1.82)
+        table.set_plan("dave@example.com", 1300, 1.82)
+        count = db_session.query(UserCredits).filter_by(user_id="dave@example.com").count()
+        assert count == 1
+
+    def test_get_balance_after_set_plan(self, table):
+        table.set_plan("eve@example.com", 3800, 1.82)
+        assert table.get_balance("eve@example.com") == 3800
+
+
+class TestAddCredits:
+    def test_creates_row_when_user_has_no_row(self, table):
+        new_balance = table.add_credits("frank@example.com", 500)
+        assert new_balance == 500
+
+    def test_increments_existing_balance(self, table):
+        table.set_plan("grace@example.com", 1300, 1.82)
+        new_balance = table.add_credits("grace@example.com", 200)
+        assert new_balance == 1500
+
+    def test_does_not_change_rate_on_top_up(self, table):
+        table.set_plan("heidi@example.com", 1300, 1.82)
+        table.add_credits("heidi@example.com", 200)
+        row = table.get("heidi@example.com")
+        assert row.credits_per_eur_cent == 1.82
+
+    def test_multiple_top_ups_accumulate(self, table):
+        table.set_plan("ivan@example.com", 1300, 1.82)
+        table.add_credits("ivan@example.com", 100)
+        table.add_credits("ivan@example.com", 100)
+        assert table.get_balance("ivan@example.com") == 1500
+
+
+class TestRateIsolation:
+    def test_existing_user_rate_unaffected_by_set_plan_on_other_user(self, table):
+        table.set_plan("judy@example.com", 1300, 1.82)
+        table.set_plan("kate@example.com", 1300, 2.0)
+        judy = table.get("judy@example.com")
+        assert judy.credits_per_eur_cent == 1.82

--- a/backend/open_webui/tests/routers/test_billing.py
+++ b/backend/open_webui/tests/routers/test_billing.py
@@ -1,0 +1,218 @@
+"""Tests covering four billing fixes from code review:
+
+1. get_user_by_email propagates DB errors instead of swallowing them as None
+2. _check_credits_exhausted accepts user_id directly — no redundant user lookup
+3. Migration f2a3b4c5d6e7 INSERT has ON CONFLICT DO NOTHING — truly idempotent
+4. Retry-After parse guard in fetch_observations_since falls back to 60s
+"""
+import datetime
+import os
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine, text
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — get_user_by_email propagates DB errors
+# ---------------------------------------------------------------------------
+
+class TestGetUserByEmail:
+    def test_returns_none_for_missing_user(self):
+        @contextmanager
+        def _get_db(db=None):
+            session = MagicMock()
+            session.query.return_value.filter_by.return_value.first.return_value = None
+            yield session
+
+        with patch("open_webui.models.users.get_db_context", _get_db):
+            from open_webui.models.users import UsersTable
+            assert UsersTable().get_user_by_email("nobody@example.com") is None
+
+    def test_propagates_db_error(self):
+        @contextmanager
+        def _get_db(db=None):
+            session = MagicMock()
+            session.query.side_effect = Exception("DB connection lost")
+            yield session
+
+        with patch("open_webui.models.users.get_db_context", _get_db):
+            from open_webui.models.users import UsersTable
+            with pytest.raises(Exception, match="DB connection lost"):
+                UsersTable().get_user_by_email("user@example.com")
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — _check_credits_exhausted takes user_id directly
+# ---------------------------------------------------------------------------
+
+# stripe is not installed in the test env — mock it before importing the router
+import sys
+sys.modules.setdefault("stripe", MagicMock())
+import open_webui.routers.billing as _billing  # noqa: E402
+
+
+class TestCheckCreditsExhausted:
+    def test_no_user_table_lookup_performed(self):
+        """Users.get_user_by_email must never be called — user_id is passed directly."""
+        mock_billings = MagicMock()
+        mock_billings.get_by_user_id.return_value = None
+        mock_users = MagicMock()
+
+        with patch.object(_billing, "StripeBillings", mock_billings), \
+             patch.object(_billing, "CREDITS_TIERS", {"trial", "pro", "premium"}), \
+             patch("open_webui.models.users.Users", mock_users):
+            _billing._check_credits_exhausted("user@example.com", "user-uuid-123")
+            mock_users.get_user_by_email.assert_not_called()
+
+    def test_stripe_lookup_uses_user_id_arg(self):
+        mock_billings = MagicMock()
+        mock_billings.get_by_user_id.return_value = None
+
+        with patch.dict(os.environ, {"CREDITS_PER_EUR_CENT": "1.82"}), \
+             patch.object(_billing, "StripeBillings", mock_billings), \
+             patch.object(_billing, "CREDITS_TIERS", {"trial", "pro", "premium"}):
+            _billing._check_credits_exhausted("user@example.com", "user-uuid-123")
+            mock_billings.get_by_user_id.assert_called_once_with("user-uuid-123")
+
+    def test_skips_non_credits_plan(self):
+        record = MagicMock()
+        record.plan_tier = "internal"
+        mock_billings = MagicMock()
+        mock_billings.get_by_user_id.return_value = record
+
+        with patch.object(_billing, "StripeBillings", mock_billings), \
+             patch.object(_billing, "CREDITS_TIERS", {"trial", "pro", "premium"}):
+            _billing._check_credits_exhausted("user@example.com", "user-uuid-123")
+
+    def test_raises_402_when_credits_exhausted(self):
+        from fastapi import HTTPException
+
+        record = MagicMock()
+        record.plan_tier = "pro"
+        record.created_at = 0
+
+        credits_row = MagicMock()
+        credits_row.balance = 100
+        credits_row.credits_per_eur_cent = 1.82
+
+        mock_billings = MagicMock()
+        mock_billings.get_by_user_id.return_value = record
+        mock_uc_db = MagicMock()
+        mock_uc_db.get.return_value = credits_row
+
+        with patch.dict(os.environ, {"CREDITS_PER_EUR_CENT": "1.82"}), \
+             patch.object(_billing, "StripeBillings", mock_billings), \
+             patch.object(_billing, "CREDITS_TIERS", {"trial", "pro", "premium"}), \
+             patch.object(_billing, "PLAN_TIER_TRIAL", "trial"), \
+             patch.object(_billing, "_get_user_current_month_cost", return_value=1.0):
+            import open_webui.models.user_credits as uc_mod
+            with patch.object(uc_mod, "UserCreditsDB", mock_uc_db), \
+                 patch.object(uc_mod, "eur_to_credits", return_value=200):
+                with pytest.raises(HTTPException) as exc_info:
+                    _billing._check_credits_exhausted("user@example.com", "user-uuid-123")
+                assert exc_info.value.status_code == 402
+                assert exc_info.value.detail == "credits_exhausted"
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 — Migration ON CONFLICT DO NOTHING idempotency
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def migration_conn():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.connect() as conn:
+        conn.execute(text("""
+            CREATE TABLE "user" (id TEXT PRIMARY KEY, email TEXT NOT NULL)
+        """))
+        conn.execute(text("""
+            CREATE TABLE stripe_billing (user_id TEXT PRIMARY KEY, plan_tier TEXT NOT NULL)
+        """))
+        conn.execute(text("""
+            CREATE TABLE user_credits (
+                id TEXT PRIMARY KEY,
+                user_id TEXT UNIQUE NOT NULL,
+                balance INTEGER NOT NULL,
+                credits_per_eur_cent REAL NOT NULL,
+                updated_at INTEGER NOT NULL
+            )
+        """))
+        conn.execute(text("INSERT INTO \"user\" VALUES ('uid-1', 'alice@example.com')"))
+        conn.execute(text("INSERT INTO stripe_billing VALUES ('uid-1', 'pro')"))
+        conn.commit()
+        yield conn
+
+
+class TestBackfillMigration:
+    def _run_upgrade(self, conn):
+        with patch.dict(os.environ, {"CREDITS_PER_EUR_CENT": "1.82"}):
+            from open_webui.migrations.versions.f2a3b4c5d6e7_backfill_user_credits import upgrade
+            with patch("open_webui.migrations.versions.f2a3b4c5d6e7_backfill_user_credits.op") as mock_op:
+                mock_op.get_bind.return_value = conn
+                upgrade()
+
+    def test_inserts_row_keyed_by_email(self, migration_conn):
+        self._run_upgrade(migration_conn)
+        rows = migration_conn.execute(
+            text("SELECT user_id, balance FROM user_credits")
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "alice@example.com"
+        assert rows[0][1] == 1300
+
+    def test_idempotent_on_second_run(self, migration_conn):
+        self._run_upgrade(migration_conn)
+        self._run_upgrade(migration_conn)  # must not raise
+        count = migration_conn.execute(
+            text("SELECT COUNT(*) FROM user_credits WHERE user_id = 'alice@example.com'")
+        ).scalar()
+        assert count == 1
+
+    def test_skips_orphaned_stripe_billing_row(self, migration_conn):
+        migration_conn.execute(text("INSERT INTO stripe_billing VALUES ('orphan-uid', 'trial')"))
+        migration_conn.commit()
+        self._run_upgrade(migration_conn)
+        user_ids = {r[0] for r in migration_conn.execute(
+            text("SELECT user_id FROM user_credits")
+        ).fetchall()}
+        assert "alice@example.com" in user_ids
+        assert "orphan-uid" not in user_ids
+
+
+# ---------------------------------------------------------------------------
+# Fix 4 — Retry-After parse guard
+# ---------------------------------------------------------------------------
+
+class TestRetryAfterParsing:
+    def _run_fetch(self, retry_after_value):
+        import open_webui.langfuse.observations as obs_module
+
+        resp_429 = MagicMock()
+        resp_429.status_code = 429
+        resp_429.headers = (
+            {"Retry-After": retry_after_value} if retry_after_value is not None else {}
+        )
+        resp_ok = MagicMock()
+        resp_ok.status_code = 200
+        resp_ok.json.return_value = {"data": [], "meta": {"totalPages": 1}}
+
+        with patch("open_webui.langfuse.observations.requests.get", side_effect=[resp_429, resp_ok]), \
+             patch("open_webui.langfuse.observations.time.sleep") as mock_sleep, \
+             patch("open_webui.langfuse.observations.load_env", return_value=("pk", "sk", "https://host")), \
+             patch("open_webui.langfuse.observations.auth_header", return_value={}):
+            list(obs_module.fetch_observations_since(datetime.datetime(2024, 1, 1)))
+            return mock_sleep
+
+    def test_integer_retry_after_is_respected(self):
+        mock_sleep = self._run_fetch("30")
+        mock_sleep.assert_called_once_with(30)
+
+    def test_http_date_retry_after_falls_back_to_60(self):
+        mock_sleep = self._run_fetch("Fri, 27 Jun 2026 10:00:00 GMT")
+        mock_sleep.assert_called_once_with(60)
+
+    def test_missing_retry_after_defaults_to_60(self):
+        mock_sleep = self._run_fetch(None)
+        mock_sleep.assert_called_once_with(60)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,6 +13,7 @@ PyJWT[crypto]==2.10.1
 authlib==1.6.6
 
 requests==2.32.5
+cachetools==5.5.2
 aiohttp==3.13.2
 async-timeout
 aiocache

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,6 +114,8 @@
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/svelte": "^5.3.1",
 				"@testing-library/user-event": "^14.6.1",
+				"@types/file-saver": "^2.0.7",
+				"@types/uuid": "^10.0.0",
 				"@typescript-eslint/eslint-plugin": "^8.31.1",
 				"@typescript-eslint/parser": "^8.31.1",
 				"cypress": "^13.15.0",
@@ -137,7 +139,7 @@
 				"vitest": "^3.2.6"
 			},
 			"engines": {
-				"node": ">=22.12.0 <=22.x.x || >=23.0.0",
+				"node": ">=22.13.0 <=22.x.x || >=23.0.0",
 				"npm": ">=6.0.0"
 			}
 		},
@@ -5099,6 +5101,13 @@
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"license": "MIT"
 		},
+		"node_modules/@types/file-saver": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.7.tgz",
+			"integrity": "sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/geojson": {
 			"version": "7946.0.16",
 			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -5202,6 +5211,13 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
 			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"license": "MIT"
+		},
+		"node_modules/@types/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/yauzl": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/svelte": "^5.3.1",
 		"@testing-library/user-event": "^14.6.1",
+		"@types/file-saver": "^2.0.7",
+		"@types/uuid": "^10.0.0",
 		"@typescript-eslint/eslint-plugin": "^8.31.1",
 		"@typescript-eslint/parser": "^8.31.1",
 		"cypress": "^13.15.0",

--- a/src/lib/apis/billing/index.ts
+++ b/src/lib/apis/billing/index.ts
@@ -1,8 +1,9 @@
 import { WEBUI_API_BASE_URL } from '$lib/constants';
+import type { PlanTier } from '$lib/billing/planTiers';
 
 export type BillingStatus = {
 	enabled: boolean;
-	plan_tier: 'internal' | 'trial' | 'paid' | 'team' | 'team_member' | null;
+	plan_tier: PlanTier | null;
 	is_configured: boolean;
 
 	// Trial
@@ -102,6 +103,10 @@ export type MyUsage = {
 	total_cost_eur: number;
 	exchange_rates: ExchangeRateEntry[];
 	ledger_ready: boolean;
+	credits_balance: number;
+	credits_used: number;
+	credits_remaining: number;
+	credits_per_eur_cent: number; // 0 = internal (credits not applicable)
 };
 
 export const getMyUsage = (token: string) => request<MyUsage>(`${base}/my-usage`, token);

--- a/src/lib/billing/planTiers.test.ts
+++ b/src/lib/billing/planTiers.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { PLAN_TIER, CREDITS_TIERS, isCreditsUser, isInternalUser } from './planTiers';
+
+describe('isCreditsUser()', () => {
+	it('returns true for trial', () => expect(isCreditsUser(PLAN_TIER.TRIAL)).toBe(true));
+	it('returns true for pro', () => expect(isCreditsUser(PLAN_TIER.PRO)).toBe(true));
+	it('returns true for premium', () => expect(isCreditsUser(PLAN_TIER.PREMIUM)).toBe(true));
+	it('returns false for internal', () => expect(isCreditsUser(PLAN_TIER.INTERNAL)).toBe(false));
+	it('returns false for team', () => expect(isCreditsUser(PLAN_TIER.TEAM)).toBe(false));
+	it('returns false for null', () => expect(isCreditsUser(null)).toBe(false));
+	it('returns false for undefined', () => expect(isCreditsUser(undefined)).toBe(false));
+	it('returns false for legacy "paid"', () => expect(isCreditsUser('paid' as any)).toBe(false));
+});
+
+describe('isInternalUser()', () => {
+	it('returns true for internal', () => expect(isInternalUser(PLAN_TIER.INTERNAL)).toBe(true));
+	it('returns false for trial', () => expect(isInternalUser(PLAN_TIER.TRIAL)).toBe(false));
+	it('returns false for pro', () => expect(isInternalUser(PLAN_TIER.PRO)).toBe(false));
+	it('returns false for null', () => expect(isInternalUser(null)).toBe(false));
+	it('returns false for undefined', () => expect(isInternalUser(undefined)).toBe(false));
+});
+
+describe('CREDITS_TIERS does not contain legacy "paid"', () => {
+	it('"paid" is not a credits tier', () => expect(CREDITS_TIERS.has('paid' as any)).toBe(false));
+});

--- a/src/lib/billing/planTiers.ts
+++ b/src/lib/billing/planTiers.ts
@@ -1,0 +1,24 @@
+export const PLAN_TIER = {
+	INTERNAL:    'internal',
+	TRIAL:       'trial',
+	PRO:         'pro',
+	PREMIUM:     'premium',
+	TEAM:        'team',
+	TEAM_MEMBER: 'team_member',
+} as const;
+
+export type PlanTier = typeof PLAN_TIER[keyof typeof PLAN_TIER];
+
+export const CREDITS_TIERS = new Set<PlanTier>([
+	PLAN_TIER.TRIAL,
+	PLAN_TIER.PRO,
+	PLAN_TIER.PREMIUM,
+]);
+
+export function isCreditsUser(tier: PlanTier | null | undefined): boolean {
+	return !!tier && CREDITS_TIERS.has(tier as PlanTier);
+}
+
+export function isInternalUser(tier: PlanTier | null | undefined): boolean {
+	return tier === PLAN_TIER.INTERNAL;
+}

--- a/src/lib/components/billing/CreditsExhaustedModal.svelte
+++ b/src/lib/components/billing/CreditsExhaustedModal.svelte
@@ -5,6 +5,8 @@
 	const dispatch = createEventDispatcher<{ close: void }>();
 </script>
 
+<svelte:window on:keydown={(e) => { if (e.key === 'Escape') dispatch('close'); }} />
+
 <div
 	class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
 	on:click|self={() => dispatch('close')}

--- a/src/lib/components/billing/CreditsExhaustedModal.svelte
+++ b/src/lib/components/billing/CreditsExhaustedModal.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { getContext, createEventDispatcher } from 'svelte';
+
+	const i18n = getContext('i18n');
+	const dispatch = createEventDispatcher<{ close: void }>();
+</script>
+
+<div
+	class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+	on:click|self={() => dispatch('close')}
+	on:keydown|self={(e) => { if (e.key === 'Escape') dispatch('close'); }}
+	role="dialog"
+	aria-modal="true"
+	tabindex="-1"
+>
+	<div class="bg-white dark:bg-gray-900 rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6 space-y-4">
+		<div class="flex items-start gap-3">
+			<span class="text-2xl" aria-hidden="true">⚠</span>
+			<div>
+				<h2 class="font-semibold text-base">{$i18n.t('Credits exhausted')}</h2>
+				<p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+					{$i18n.t("You've used all your credits for this month. Top up or upgrade to continue chatting.")}
+				</p>
+			</div>
+		</div>
+
+		<div class="flex gap-2">
+			<a
+				href="/billing"
+				on:click={() => dispatch('close')}
+				class="flex-1 text-center py-2.5 rounded-lg text-sm bg-blue-600 text-white hover:bg-blue-700 transition font-medium"
+			>
+				{$i18n.t('Go to billing →')}
+			</a>
+			<button
+				on:click={() => dispatch('close')}
+				class="flex-1 py-2.5 rounded-lg text-sm border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition font-medium"
+			>
+				{$i18n.t('Dismiss')}
+			</button>
+		</div>
+	</div>
+</div>

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1593,7 +1593,11 @@
 
 			if (lastMessage.error && !lastMessage.content) {
 				// Error in response
-				toast.error($i18n.t(`Oops! There was an error in the previous response.`));
+				if (lastMessage.error.content?.includes('credits_exhausted')) {
+					window.dispatchEvent(new CustomEvent('billing:credits_exhausted'));
+				} else {
+					toast.error($i18n.t(`Oops! There was an error in the previous response.`));
+				}
 				return;
 			}
 		}
@@ -2046,7 +2050,11 @@
 		console.error(innerError); // allow-console
 		if ('detail' in innerError) {
 			// FastAPI error
-			toast.error(innerError.detail);
+			if (innerError.detail === 'credits_exhausted') {
+				window.dispatchEvent(new CustomEvent('billing:credits_exhausted'));
+			} else {
+				toast.error(innerError.detail);
+			}
 			errorMessage = innerError.detail;
 		} else if ('error' in innerError) {
 			// OpenAI error

--- a/src/lib/components/chat/creditsExhausted.test.ts
+++ b/src/lib/components/chat/creditsExhausted.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+/**
+ * Credits-exhausted error handling tests.
+ *
+ * Covers the two paths in Chat.svelte that must show the credits modal
+ * instead of a generic toast:
+ *
+ * 1. handleOpenAIError — when the FastAPI error detail is 'credits_exhausted',
+ *    dispatch billing:credits_exhausted and skip the toast.
+ *
+ * 2. Submit guard — when the previous message already has a credits_exhausted
+ *    error and the user hits send again, dispatch the event instead of
+ *    showing "Oops! There was an error in the previous response."
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Inline implementations that mirror exactly what Chat.svelte does.
+// These are not imports — they live here so the test is self-contained and
+// won't break if Chat.svelte is refactored internally.
+// ---------------------------------------------------------------------------
+
+const toast = { error: vi.fn() };
+
+function handleOpenAIError(error: unknown): void {
+	const innerError = error as Record<string, unknown>;
+
+	if ('detail' in innerError) {
+		if (innerError.detail === 'credits_exhausted') {
+			window.dispatchEvent(new CustomEvent('billing:credits_exhausted'));
+		} else {
+			toast.error(innerError.detail);
+		}
+	} else if ('error' in innerError && typeof innerError.error === 'object') {
+		const e = innerError.error as Record<string, unknown>;
+		toast.error('message' in e ? e.message : e);
+	} else if ('message' in innerError) {
+		toast.error(innerError.message);
+	}
+}
+
+function handleSubmitWithPreviousError(errorContent: string | undefined): void {
+	if (errorContent?.includes('credits_exhausted')) {
+		window.dispatchEvent(new CustomEvent('billing:credits_exhausted'));
+	} else {
+		toast.error('Oops! There was an error in the previous response.');
+	}
+}
+
+// ---------------------------------------------------------------------------
+
+describe('credits_exhausted — handleOpenAIError', () => {
+	let fired: boolean;
+
+	beforeEach(() => {
+		fired = false;
+		vi.clearAllMocks();
+		window.addEventListener('billing:credits_exhausted', () => { fired = true; });
+	});
+
+	afterEach(() => {
+		window.removeEventListener('billing:credits_exhausted', () => {});
+	});
+
+	it('dispatches billing:credits_exhausted and does not toast', () => {
+		handleOpenAIError({ detail: 'credits_exhausted' });
+		expect(fired).toBe(true);
+		expect(toast.error).not.toHaveBeenCalled();
+	});
+
+	it('toasts and does not dispatch for other FastAPI errors', () => {
+		handleOpenAIError({ detail: 'Unauthorized' });
+		expect(fired).toBe(false);
+		expect(toast.error).toHaveBeenCalledWith('Unauthorized');
+	});
+
+	it('toasts OpenAI-style errors with message field', () => {
+		handleOpenAIError({ error: { message: 'model not found' } });
+		expect(fired).toBe(false);
+		expect(toast.error).toHaveBeenCalledWith('model not found');
+	});
+});
+
+describe('credits_exhausted — submit guard (previous message has error)', () => {
+	let fired: boolean;
+	let handler: () => void;
+
+	beforeEach(() => {
+		fired = false;
+		vi.clearAllMocks();
+		handler = () => { fired = true; };
+		window.addEventListener('billing:credits_exhausted', handler);
+	});
+
+	afterEach(() => {
+		window.removeEventListener('billing:credits_exhausted', handler);
+	});
+
+	it('dispatches billing:credits_exhausted when previous error contains credits_exhausted', () => {
+		handleSubmitWithPreviousError('Uh-oh! There was an issue with the response.\ncredits_exhausted');
+		expect(fired).toBe(true);
+		expect(toast.error).not.toHaveBeenCalled();
+	});
+
+	it('shows Oops toast for generic previous errors', () => {
+		handleSubmitWithPreviousError('Uh-oh! There was an issue with the response.\nUnauthorized');
+		expect(fired).toBe(false);
+		expect(toast.error).toHaveBeenCalledWith('Oops! There was an error in the previous response.');
+	});
+
+	it('shows Oops toast when error content is undefined', () => {
+		handleSubmitWithPreviousError(undefined);
+		expect(fired).toBe(false);
+		expect(toast.error).toHaveBeenCalledWith('Oops! There was an error in the previous response.');
+	});
+});

--- a/src/lib/components/chat/creditsExhausted.test.ts
+++ b/src/lib/components/chat/creditsExhausted.test.ts
@@ -51,15 +51,17 @@ function handleSubmitWithPreviousError(errorContent: string | undefined): void {
 
 describe('credits_exhausted — handleOpenAIError', () => {
 	let fired: boolean;
+	let handler: () => void;
 
 	beforeEach(() => {
 		fired = false;
 		vi.clearAllMocks();
-		window.addEventListener('billing:credits_exhausted', () => { fired = true; });
+		handler = () => { fired = true; };
+		window.addEventListener('billing:credits_exhausted', handler);
 	});
 
 	afterEach(() => {
-		window.removeEventListener('billing:credits_exhausted', () => {});
+		window.removeEventListener('billing:credits_exhausted', handler);
 	});
 
 	it('dispatches billing:credits_exhausted and does not toast', () => {

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -41,7 +41,7 @@
 		importChat
 	} from '$lib/apis/chats';
 	import { createNewFolder, getFolders, updateFolderParentIdById } from '$lib/apis/folders';
-	import { PLAN_TIER, isInternalUser } from '$lib/billing/planTiers';
+	import { isInternalUser } from '$lib/billing/planTiers';
 
 	import ArchivedChatsModal from './ArchivedChatsModal.svelte';
 	import UserMenu from './Sidebar/UserMenu.svelte';
@@ -1272,9 +1272,14 @@
 											<div class="text-xs text-gray-500 dark:text-gray-400 cursor-default">
 												{$i18n.t('This month')}:
 												{#if isInternalUser($billingStatus?.plan_tier)}
-													<span class="font-medium text-gray-700 dark:text-gray-300">€{(myUsage.total_cost_eur ?? 0).toFixed(2)}</span>
+													<span class="font-medium text-gray-700 dark:text-gray-300"
+														>€{(myUsage.total_cost_eur ?? 0).toFixed(2)}</span
+													>
 												{:else}
-													<span class="font-medium text-gray-700 dark:text-gray-300">{myUsage.credits_used ?? 0} / {myUsage.credits_balance} {$i18n.t('credits')}</span>
+													<span class="font-medium text-gray-700 dark:text-gray-300"
+														>{myUsage.credits_used ?? 0} / {myUsage.credits_balance}
+														{$i18n.t('credits')}</span
+													>
 												{/if}
 											</div>
 										</Tooltip>

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -7,7 +7,6 @@
 		user,
 		chats,
 		settings,
-		showSettings,
 		chatId,
 		tags,
 		folders as _folders,
@@ -25,7 +24,8 @@
 		isApp,
 		models,
 		selectedFolder,
-		WEBUI_NAME
+		WEBUI_NAME,
+		billingStatus
 	} from '$lib/stores';
 	import { onMount, getContext, tick, onDestroy } from 'svelte';
 
@@ -41,6 +41,7 @@
 		importChat
 	} from '$lib/apis/chats';
 	import { createNewFolder, getFolders, updateFolderParentIdById } from '$lib/apis/folders';
+	import { PLAN_TIER, isInternalUser } from '$lib/billing/planTiers';
 
 	import ArchivedChatsModal from './ArchivedChatsModal.svelte';
 	import UserMenu from './Sidebar/UserMenu.svelte';
@@ -103,7 +104,7 @@
 				const monthName = new Date(myUsage.year, myUsage.month - 1).toLocaleString('default', {
 					month: 'long'
 				});
-				return `<div class="text-left space-y-0.5"><div class="font-semibold mb-1">${monthName} ${myUsage.year}</div><div>Total tokens: ${myUsage.total_tokens.toLocaleString()}</div><div>Estimated cost: €${(myUsage.total_cost_eur ?? 0).toFixed(2)}</div></div>`;
+				return `<div class="text-left space-y-0.5"><div class="font-semibold mb-1">${monthName} ${myUsage.year}</div><div>Total tokens: ${myUsage.total_tokens.toLocaleString()}</div></div>`;
 			})()
 		: '';
 
@@ -1270,9 +1271,11 @@
 										>
 											<div class="text-xs text-gray-500 dark:text-gray-400 cursor-default">
 												{$i18n.t('This month')}:
-												<span class="font-medium text-gray-700 dark:text-gray-300"
-													>€{(myUsage.total_cost_eur ?? 0).toFixed(2)}</span
-												>
+												{#if isInternalUser($billingStatus?.plan_tier)}
+													<span class="font-medium text-gray-700 dark:text-gray-300">€{(myUsage.total_cost_eur ?? 0).toFixed(2)}</span>
+												{:else}
+													<span class="font-medium text-gray-700 dark:text-gray-300">{myUsage.credits_used ?? 0} / {myUsage.credits_balance} {$i18n.t('credits')}</span>
+												{/if}
 											</div>
 										</Tooltip>
 									{:else}

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -4,6 +4,7 @@ import type { ModelConfig } from '$lib/apis';
 import type { Banner } from '$lib/types';
 import type { Socket } from 'socket.io-client';
 import { isDev, isStaging } from '$lib/utils';
+import type { BillingStatus, MyUsage } from '$lib/apis/billing';
 
 import emojiShortCodes from '$lib/emoji-shortcodes.json';
 
@@ -81,6 +82,9 @@ export const functions = writable(null);
 export const toolServers = writable([]);
 
 export const banners: Writable<Banner[]> = writable([]);
+
+export const billingStatus: Writable<BillingStatus | null> = writable(null);
+export const myUsage: Writable<MyUsage | null> = writable(null);
 
 export const settings: Writable<Settings> = writable({});
 

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { toast } from 'svelte-sonner';
-	import { onMount, tick, getContext } from 'svelte';
+	import { onMount, onDestroy, tick, getContext } from 'svelte';
 	import { openDB, deleteDB } from 'idb';
 	import fileSaver from 'file-saver';
 	const { saveAs } = fileSaver;
@@ -14,7 +14,7 @@
 	import { getBanners } from '$lib/apis/configs';
 	import { getUserSettings } from '$lib/apis/users';
 	import { getBillingStatus, getMyUsage, type BillingStatus } from '$lib/apis/billing';
-	import { PLAN_TIER, isCreditsUser } from '$lib/billing/planTiers';
+	import { PLAN_TIER } from '$lib/billing/planTiers';
 
 	import { WEBUI_VERSION } from '$lib/constants';
 	import { compareVersion } from '$lib/utils';
@@ -73,8 +73,14 @@
 			billingStatusStore.set(billingStatus);
 			const isPastDue = billingStatus?.subscription_status === 'past_due';
 			showPastDueBanner = isPastDue;
+			const capturedStatus = billingStatus;
 			getMyUsage(localStorage.token)
-				.then((u) => myUsageStore.set(u))
+				.then((u) => {
+					myUsageStore.set(u);
+					const isTrialExhausted =
+						capturedStatus?.plan_tier === PLAN_TIER.TRIAL && (u?.credits_remaining ?? 1) <= 0;
+					if (isTrialExhausted) showPastDueBanner = true;
+				})
 				.catch(() => {});
 		} catch {
 			// Billing unavailable — don't block the user
@@ -178,9 +184,9 @@
 			return;
 		}
 
-		window.addEventListener('billing:credits_exhausted', () => {
-			showCreditsExhaustedModal = true;
-		});
+		const onCreditsExhausted = () => { showCreditsExhaustedModal = true; };
+		window.addEventListener('billing:credits_exhausted', onCreditsExhausted);
+		onDestroy(() => window.removeEventListener('billing:credits_exhausted', onCreditsExhausted));
 
 		clearChatInputStorage();
 		await Promise.all([

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -13,7 +13,8 @@
 	import { getTools } from '$lib/apis/tools';
 	import { getBanners } from '$lib/apis/configs';
 	import { getUserSettings } from '$lib/apis/users';
-	import { getBillingStatus, type BillingStatus } from '$lib/apis/billing';
+	import { getBillingStatus, getMyUsage, type BillingStatus } from '$lib/apis/billing';
+	import { PLAN_TIER, isCreditsUser } from '$lib/billing/planTiers';
 
 	import { WEBUI_VERSION } from '$lib/constants';
 	import { compareVersion } from '$lib/utils';
@@ -35,7 +36,9 @@
 		temporaryChatEnabled,
 		toolServers,
 		showSearch,
-		showSidebar
+		showSidebar,
+		billingStatus as billingStatusStore,
+		myUsage as myUsageStore
 	} from '$lib/stores';
 
 	import Sidebar from '$lib/components/layout/Sidebar.svelte';
@@ -47,6 +50,7 @@
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import { shouldShowTrustminderFeedback } from '$lib/utils/featureGates';
 	import { Shortcut, shortcuts } from '$lib/shortcuts';
+	import CreditsExhaustedModal from '$lib/components/billing/CreditsExhaustedModal.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -60,16 +64,18 @@
 	};
 	let billingStatus: BillingStatus | null = null;
 	let showPastDueBanner = false;
+	let showCreditsExhaustedModal = false;
 
 	const checkBillingStatus = async () => {
 		if (!($config?.features?.enable_billing ?? false)) return;
-		if ($user?.role === 'admin') return;
 		try {
 			billingStatus = await getBillingStatus(localStorage.token);
+			billingStatusStore.set(billingStatus);
 			const isPastDue = billingStatus?.subscription_status === 'past_due';
-			const isCreditExhausted =
-				billingStatus?.plan_tier === 'trial' && (billingStatus?.credit_remaining_eur ?? 1) <= 0;
-			showPastDueBanner = isPastDue || isCreditExhausted;
+			showPastDueBanner = isPastDue;
+			getMyUsage(localStorage.token)
+				.then((u) => myUsageStore.set(u))
+				.catch(() => {});
 		} catch {
 			// Billing unavailable — don't block the user
 		}
@@ -171,6 +177,10 @@
 		if (!['user', 'admin'].includes($user?.role)) {
 			return;
 		}
+
+		window.addEventListener('billing:credits_exhausted', () => {
+			showCreditsExhaustedModal = true;
+		});
 
 		clearChatInputStorage();
 		await Promise.all([
@@ -411,7 +421,7 @@
 						class="fixed top-0 left-0 right-0 z-50 flex items-center justify-between gap-4 bg-red-600 text-white px-4 py-2.5 text-sm"
 					>
 						<span>
-							{#if billingStatus?.plan_tier === 'trial'}
+							{#if billingStatus?.plan_tier === PLAN_TIER.TRIAL}
 								{$i18n.t('Your trial credit is used up. Please')}
 								<a href="/billing" class="underline font-semibold hover:opacity-80">
 									{$i18n.t('upgrade your plan')}
@@ -453,6 +463,10 @@
 			{/if}
 		</div>
 	</div>
+{/if}
+
+{#if showCreditsExhaustedModal}
+	<CreditsExhaustedModal on:close={() => (showCreditsExhaustedModal = false)} />
 {/if}
 
 <style>

--- a/src/routes/(app)/admin/billing/+page.svelte
+++ b/src/routes/(app)/admin/billing/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount, getContext } from 'svelte';
 	import { toast } from 'svelte-sonner';
 	import { getAdminBillingSummary, type AdminBillingRow } from '$lib/apis/billing';
+	import { PLAN_TIER } from '$lib/billing/planTiers';
 
 	const i18n = getContext('i18n');
 
@@ -37,8 +38,8 @@
 	});
 
 	$: totalCost = rows.reduce((s, r) => s + r.current_month_cost_eur, 0);
-	$: paidCount = rows.filter((r) => r.plan_tier === 'paid' && r.subscription_status === 'active').length;
-	$: trialCount = rows.filter((r) => r.plan_tier === 'trial').length;
+	$: paidCount = rows.filter((r) => (r.plan_tier === PLAN_TIER.PRO || r.plan_tier === PLAN_TIER.PREMIUM) && r.subscription_status === 'active').length;
+	$: trialCount = rows.filter((r) => r.plan_tier === PLAN_TIER.TRIAL).length;
 	$: pastDueCount = rows.filter((r) => r.subscription_status === 'past_due').length;
 </script>
 

--- a/src/routes/(app)/billing/+page.svelte
+++ b/src/routes/(app)/billing/+page.svelte
@@ -860,11 +860,11 @@
 {/if}
 
 <!-- ===== REMOVE MEMBER CONFIRM ===== -->
+<svelte:window on:keydown={(e) => { if (e.key === 'Escape' && pendingRemoveUserId) { pendingRemoveUserId = null; pendingRemoveName = null; } }} />
 {#if pendingRemoveUserId}
 	<div
 		class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
 		on:click|self={() => { pendingRemoveUserId = null; pendingRemoveName = null; }}
-		on:keydown|self={(e) => { if (e.key === 'Escape') { pendingRemoveUserId = null; pendingRemoveName = null; } }}
 		role="dialog"
 		aria-modal="true"
 		tabindex="-1"

--- a/src/routes/(app)/billing/+page.svelte
+++ b/src/routes/(app)/billing/+page.svelte
@@ -16,18 +16,23 @@
 		inviteTeamMember,
 		removeTeamMember,
 		getModelBreakdown,
+		getMyUsage,
 		type BillingStatus,
 		type TopupOption,
 		type TeamTier,
 		type TeamStatus,
-		type ModelBreakdown
+		type ModelBreakdown,
+		type MyUsage
 	} from '$lib/apis/billing';
+	import { PLAN_TIER, isCreditsUser as _isCreditsUser, isInternalUser } from '$lib/billing/planTiers';
 
 	const i18n = getContext('i18n');
 
 	let status: BillingStatus | null = null;
 	let teamStatus: TeamStatus | null = null;
 	let modelBreakdown: ModelBreakdown | null = null;
+	let myUsage: MyUsage | null = null;
+	let showCredits = false;
 	let loading = true;
 
 	let checkingOut = false;
@@ -52,6 +57,8 @@
 
 	// Member actions
 	let openMenuUserId: string | null = null;
+	let pendingRemoveUserId: string | null = null;
+	let pendingRemoveName: string | null = null;
 
 	const currentMonth = new Date().toLocaleString('default', { month: 'long', year: 'numeric' });
 
@@ -74,13 +81,18 @@
 
 			if (status?.enabled) {
 				extras.push(getModelBreakdown(localStorage.token).then((d) => (modelBreakdown = d)).catch(() => {}));
+				extras.push(
+					getMyUsage(localStorage.token)
+						.then((d) => { myUsage = d; })
+						.catch(() => {})
+				);
 			}
 
-			if (status?.plan_tier === 'team') {
+			if (status?.plan_tier === PLAN_TIER.TEAM) {
 				extras.push(getTeamStatus(localStorage.token).then((d) => (teamStatus = d)).catch(() => {}));
 				extras.push(getTopupOptions(localStorage.token).then((d) => (topupOptions = d)).catch(() => {}));
 			}
-			if (status?.plan_tier === 'trial' || status?.plan_tier === 'paid') {
+			if (status?.plan_tier === PLAN_TIER.TRIAL || status?.plan_tier === PLAN_TIER.PRO || status?.plan_tier === PLAN_TIER.PREMIUM) {
 				extras.push(getTeamTiers(localStorage.token).then((d) => (teamTiers = d)).catch(() => {}));
 			}
 
@@ -164,9 +176,18 @@
 		}
 	};
 
-	const handleRemoveMember = async (userId: string, name: string) => {
+	const handleRemoveMember = (userId: string, name: string) => {
 		openMenuUserId = null;
-		if (!confirm($i18n.t('Remove {{name}} from the team?', { name }))) return;
+		pendingRemoveUserId = userId;
+		pendingRemoveName = name;
+	};
+
+	const confirmRemoveMember = async () => {
+		if (!pendingRemoveUserId) return;
+		const userId = pendingRemoveUserId;
+		const name = pendingRemoveName ?? '';
+		pendingRemoveUserId = null;
+		pendingRemoveName = null;
 		try {
 			await removeTeamMember(localStorage.token, userId);
 			toast.success($i18n.t('{{name}} removed from team', { name }));
@@ -200,12 +221,25 @@
 		return AVATAR_COLORS[Math.abs(h) % AVATAR_COLORS.length];
 	}
 
-	$: trialPct =
-		status?.plan_tier === 'trial' && (status.credit_limit_eur ?? 0) > 0
-			? Math.min(100, ((status.credit_used_eur ?? 0) / status.credit_limit_eur) * 100)
+	$: isCreditsUser = _isCreditsUser(status?.plan_tier) && (myUsage?.credits_per_eur_cent ?? 0) > 0;
+	$: showCredits = !!status && !isInternalUser(status.plan_tier) && status.plan_tier !== null;
+
+	// What percentage of the credits balance has been consumed (0–100)
+	$: creditsUsedPercentage =
+		isCreditsUser && (myUsage?.credits_balance ?? 0) > 0
+			? Math.min(100, ((myUsage?.credits_used ?? 0) / (myUsage?.credits_balance ?? 1)) * 100)
 			: 0;
 
+	$: trialPct = creditsUsedPercentage;
 	$: trialLowBalance = trialPct >= 75;
+
+	// Format a EUR cost as either "€0.0042" or "7 cr" depending on the active display tab
+	$: formatCost = (eur: number) => {
+		if (showCredits && myUsage && myUsage.credits_per_eur_cent > 0) {
+			return `${Math.round(eur * 100 * myUsage.credits_per_eur_cent).toLocaleString()} cr`;
+		}
+		return `€${eur.toFixed(2)}`;
+	};
 
 	$: teamBudgetTotal =
 		(status?.usage_budget_eur ?? 0) + (status?.extra_credit_eur ?? 0);
@@ -247,12 +281,14 @@
 		</div>
 
 	{:else}
-		<p class="text-xs text-gray-400 dark:text-gray-500 font-medium uppercase tracking-wide pb-2">
-			{$i18n.t('Plan & subscription')}
-		</p>
+		<div class="pb-2">
+			<p class="text-xs text-gray-400 dark:text-gray-500 font-medium uppercase tracking-wide">
+				{$i18n.t('Plan & subscription')}
+			</p>
+		</div>
 
 		<!-- ===== INTERNAL ===== -->
-		{#if status.plan_tier === 'internal'}
+		{#if status.plan_tier === PLAN_TIER.INTERNAL}
 			<div class="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6">
 				<div class="flex items-start justify-between gap-4">
 					<div>
@@ -270,15 +306,21 @@
 			</div>
 
 		<!-- ===== FREE TRIAL ===== -->
-		{:else if status.plan_tier === 'trial'}
+		{:else if status.plan_tier === PLAN_TIER.TRIAL}
 			<div class="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6">
 				<div class="flex items-start justify-between gap-4 flex-wrap">
 					<div>
 						<h2 class="text-lg font-bold">{$i18n.t('Free Trial')}</h2>
 						<div class="flex items-center gap-2 mt-1">
-							<span class="text-sm {trialLowBalance ? 'text-red-500' : 'text-gray-500 dark:text-gray-400'}">
-								€{status.credit_used_eur.toFixed(2)} {$i18n.t('of')} €{status.credit_limit_eur.toFixed(2)} {$i18n.t('used')}
-							</span>
+							{#if showCredits && myUsage}
+								<span class="text-sm {trialLowBalance ? 'text-red-500' : 'text-gray-500 dark:text-gray-400'}">
+									{myUsage.credits_used.toLocaleString()} {$i18n.t('of')} {myUsage.credits_balance.toLocaleString()} {$i18n.t('credits used')}
+								</span>
+							{:else}
+								<span class="text-sm {trialLowBalance ? 'text-red-500' : 'text-gray-500 dark:text-gray-400'}">
+									€{status.credit_used_eur.toFixed(2)} {$i18n.t('of')} €{status.credit_limit_eur.toFixed(2)} {$i18n.t('used')}
+								</span>
+							{/if}
 							{#if trialLowBalance}
 								<span class="text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400 font-medium">
 									{$i18n.t('Low balance')}
@@ -306,7 +348,7 @@
 				</div>
 
 				<div class="mt-4 space-y-1.5">
-					<div class="text-xs text-gray-500 dark:text-gray-400">{$i18n.t('Credit used')}</div>
+					<div class="text-xs text-gray-500 dark:text-gray-400">{$i18n.t('Credits used')}</div>
 					<div class="w-full bg-gray-100 dark:bg-gray-800 rounded-full h-2">
 						<div
 							class="h-2 rounded-full transition-all {trialLowBalance ? 'bg-red-500' : 'bg-green-500'}"
@@ -316,8 +358,10 @@
 				</div>
 
 				<p class="text-sm text-gray-500 dark:text-gray-400 mt-3">
-					{#if status.credit_remaining_eur <= 0}
+					{#if isCreditsUser && myUsage && myUsage.credits_remaining <= 0}
 						{$i18n.t('Your free exploratory credits are exhausted. Upgrade to continue using Hubgate.')}
+					{:else if isCreditsUser && myUsage}
+						{$i18n.t('You have')} <strong>{showCredits ? `${myUsage.credits_remaining.toLocaleString()} cr` : `€${status.credit_remaining_eur.toFixed(2)}`}</strong> {$i18n.t('remaining of your free exploratory credits. Upgrade to continue using Hubgate after your trial ends.')}
 					{:else}
 						{$i18n.t('You have')} <strong>€{status.credit_remaining_eur.toFixed(2)}</strong> {$i18n.t('remaining of your free exploratory credits. Upgrade to continue using Hubgate after your trial ends.')}
 					{/if}
@@ -325,16 +369,44 @@
 			</div>
 
 		<!-- ===== PAID ===== -->
-		{:else if status.plan_tier === 'paid'}
+		{:else if status.plan_tier === PLAN_TIER.PRO || status.plan_tier === PLAN_TIER.PREMIUM}
 			<div class="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6">
 				<div class="flex items-start justify-between gap-4 flex-wrap">
 					<div>
 						<h2 class="text-lg font-bold">{$i18n.t('Pro Plan')}</h2>
 						<div class="flex items-center gap-2 mt-1">
-							<span class="text-sm text-gray-500 dark:text-gray-400">
-								€{status.current_month_cost_eur.toFixed(2)} {$i18n.t('used this month')}
-							</span>
+							{#if showCredits && myUsage}
+								<span class="text-sm {creditsUsedPercentage >= 75 ? 'text-red-500' : 'text-gray-500 dark:text-gray-400'}">
+									{myUsage.credits_used.toLocaleString()} {$i18n.t('of')} {myUsage.credits_balance.toLocaleString()} {$i18n.t('credits used')}
+								</span>
+								{#if myUsage.credits_remaining <= 0}
+									<span class="text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400 font-medium">
+										{$i18n.t('Exhausted')}
+									</span>
+								{:else if creditsUsedPercentage >= 75}
+									<span class="text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400 font-medium">
+										{$i18n.t('Low balance')}
+									</span>
+								{/if}
+							{:else}
+								<span class="text-sm text-gray-500 dark:text-gray-400">
+									€{status.current_month_cost_eur.toFixed(2)} {$i18n.t('used this month')}
+								</span>
+							{/if}
 						</div>
+						{#if showCredits && myUsage}
+							<div class="mt-3 space-y-1.5">
+								<div class="w-full bg-gray-100 dark:bg-gray-800 rounded-full h-2">
+									<div
+										class="h-2 rounded-full transition-all {creditsUsedPercentage >= 75 ? 'bg-red-500' : 'bg-green-500'}"
+										style="width: {creditsUsedPercentage}%"
+									></div>
+								</div>
+								<div class="text-xs text-gray-500 dark:text-gray-400">
+									{myUsage.credits_remaining.toLocaleString()} {$i18n.t('credits remaining')}
+								</div>
+							</div>
+						{/if}
 					</div>
 					<div class="flex items-center gap-2 shrink-0">
 						<button
@@ -363,7 +435,7 @@
 			</div>
 
 		<!-- ===== TEAM OWNER ===== -->
-		{:else if status.plan_tier === 'team'}
+		{:else if status.plan_tier === PLAN_TIER.TEAM}
 			<div class="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6">
 				<div class="flex items-start justify-between gap-4 flex-wrap">
 					<div>
@@ -430,7 +502,7 @@
 			</div>
 
 		<!-- ===== TEAM MEMBER ===== -->
-		{:else if status.plan_tier === 'team_member'}
+		{:else if status.plan_tier === PLAN_TIER.TEAM_MEMBER}
 			<div class="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6">
 				<div class="flex items-start justify-between gap-4 flex-wrap">
 					<div>
@@ -486,21 +558,21 @@
 						<div class="flex items-center justify-between px-5 py-3.5 border-b border-gray-100 dark:border-gray-800 last:border-b-0">
 							<span class="text-sm font-medium">{m.model}</span>
 							<div class="flex items-center gap-4">
-								<span class="text-sm font-semibold">€{m.cost.toFixed(2)}</span>
+								<span class="text-sm font-semibold">{formatCost(m.cost)}</span>
 								<span class="text-xs text-gray-400 dark:text-gray-500 w-8 text-right">{m.pct}%</span>
 							</div>
 						</div>
 					{/each}
 					<div class="flex items-center justify-between px-5 py-3.5 bg-gray-50 dark:bg-gray-800/50">
 						<span class="text-sm font-medium">{$i18n.t('Total spent')} – {modelBreakdown.month}</span>
-						<span class="text-sm font-bold">€{modelBreakdown.total.toFixed(2)}</span>
+						<span class="text-sm font-bold">{formatCost(modelBreakdown.total)}</span>
 					</div>
 				</div>
 			</div>
 		{/if}
 
 		<!-- ===== TEAM LEADERBOARD (team owner only) ===== -->
-		{#if status.plan_tier === 'team' && teamStatus}
+		{#if status.plan_tier === PLAN_TIER.TEAM && teamStatus}
 			<div class="pt-6">
 				<div class="flex items-center justify-between pb-3">
 					<p class="text-xs text-gray-400 dark:text-gray-500 font-medium">
@@ -783,6 +855,39 @@
 			{#if toppingUp}
 				<div class="text-center text-sm text-gray-400 animate-pulse">{$i18n.t('Redirecting to checkout...')}</div>
 			{/if}
+		</div>
+	</div>
+{/if}
+
+<!-- ===== REMOVE MEMBER CONFIRM ===== -->
+{#if pendingRemoveUserId}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+		on:click|self={() => { pendingRemoveUserId = null; pendingRemoveName = null; }}
+		on:keydown|self={(e) => { if (e.key === 'Escape') { pendingRemoveUserId = null; pendingRemoveName = null; } }}
+		role="dialog"
+		aria-modal="true"
+		tabindex="-1"
+	>
+		<div class="bg-white dark:bg-gray-900 rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6 space-y-4">
+			<h2 class="font-semibold text-base">{$i18n.t('Remove team member?')}</h2>
+			<p class="text-sm text-gray-500 dark:text-gray-400">
+				{$i18n.t('{{name}} will lose access to the team immediately.', { name: pendingRemoveName ?? '' })}
+			</p>
+			<div class="flex gap-2">
+				<button
+					on:click={confirmRemoveMember}
+					class="flex-1 py-2.5 rounded-lg text-sm bg-red-600 text-white hover:bg-red-700 transition font-medium"
+				>
+					{$i18n.t('Remove')}
+				</button>
+				<button
+					on:click={() => { pendingRemoveUserId = null; pendingRemoveName = null; }}
+					class="flex-1 py-2.5 rounded-lg text-sm border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition font-medium"
+				>
+					{$i18n.t('Cancel')}
+				</button>
+			</div>
 		</div>
 	</div>
 {/if}


### PR DESCRIPTION
Closes: [TRAU-511](https://keepersolutions.atlassian.net/browse/TRAU-511)

### Changes

- Add migrations for plan rename and backfill for credits for existing commercial users
- Add caching of traceId to userId resolutions for langfuse observations polling
- Add cachetools dependency
- Add new env
- Add db migration, convert trial eur to credits, add credit info to my-usage endpoint, check billing checks all four planbs, expense poll adds warning of credit overage if exists after sync, check credits exahusted returns 402 when user is out of credits, add tests
- Fix wrong billing message when there are no credits (none) in the db
- Add merge migration heads for alembic
- Add retry to polling if response is 429 - too many requests
- Add credit cost to paid users, keep EUR for internal
- Add creditsExhausted tests
- Add agentic pr feedback

## New env variables
Credits conversion rate: how many credits equal 1 euro cent of Langfuse cost.
**REQUIRED when BILLING_ENABLED=true - missing value crashes on startup**.
Locked into each user's row at plan assignment; changing this only affects new signups and renewals.
`CREDITS_PER_EUR_CENT=1.82`

Interval for syncing cost; 300 seconds is a fallback if the value is not provided
`LEDGER_POLL_INTERVAL=120`

Stripe price ID for the Pro plan (overrides `STRIPE_PRICE_ID`)
`STRIPE_PRICE_ID_PRO=`

Stripe price ID for the Premium plan
`STRIPE_PRICE_ID_PREMIUM=`

## Migrations
- d4e5f6a7b8c9 | merge heads
- e5f6a7b8c9d0 | rename "paid" → "pro" in stripe_billing
- f2a3b4c5d6e7 | backfill user_credits for existing users ← HEAD



### Logs
Example of backend log when Langfuse returns 429 error
`2026-06-25 15:08:14.294 | WARNING  | open_webui.langfuse.observations:fetch_observations_since:92 - Langfuse rate limit hit (page 1), retrying in 30s`

Example of backend log when user exhausts credits. Bear in mind that, given the polling interval, sometimes users will go over limit prior to chat usage block
`2026-06-25 18:01:33.830 | WARNING  | open_webui.tasks.billing:_sync_observations:239 - [ledger-poller] credits overage: user=hadrovic1@gmail.com overshot=7 credits (balance=14 used=21)`