### PR TITLE
TRAU-517: flip PII masking toggle and expand detected data types

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1749,13 +1749,18 @@
 														>PII Masking</span
 													>
 												</div>
-												{#if piiMaskingEnabled}
-													<HgIconToggleOn class="w-5 h-5 text-hg-blue dark:text-white" />
-												{:else}
-													<HgIconToggleOff
-														class="w-5 h-5 text-hg-text-tertiary dark:text-gray-600"
+												<div class="relative w-5 h-5">
+													<HgIconToggleOn
+														class="absolute inset-0 w-5 h-5 scale-x-[-1] text-hg-blue dark:text-white transition-opacity duration-200 ease-in-out {piiMaskingEnabled
+															? 'opacity-100'
+															: 'opacity-0'}"
 													/>
-												{/if}
+													<HgIconToggleOff
+														class="absolute inset-0 w-5 h-5 scale-x-[-1] text-hg-text-tertiary dark:text-gray-600 transition-opacity duration-200 ease-in-out {piiMaskingEnabled
+															? 'opacity-0'
+															: 'opacity-100'}"
+													/>
+												</div>
 											</button>
 										</Tooltip>
 

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1730,7 +1730,7 @@
 										<!-- PII Masking toggle (stub) -->
 										<Tooltip
 											content={$i18n.t(
-												'Dynamic PII Masking: A dual-stage filter built on proven open-source NER (Microsoft Presidio and spaCy), enhanced with proprietary tuning and 15+ custom regional recognizers. It automatically detects and replaces Personally Identifiable Information (PII) with secure placeholders before queries leave your secure environment, ensuring zero raw PII reaches public LLMs.'
+												'Keeps your personal data private by masking names, phone numbers, IBANs and other personal information before sending your message to the LLM.'
 											)}
 											placement="top"
 										>

--- a/src/lib/components/chat/Settings/Privacy.svelte
+++ b/src/lib/components/chat/Settings/Privacy.svelte
@@ -16,24 +16,29 @@
 			label: 'Identity',
 			items: [
 				'Person names',
-				'HR OIB',
-				'HR JMBG',
+				'Usernames',
 				'IE PPSN',
-				'RO CNP',
 				'UK NINO',
 				'UK UTR',
 				'UK NHS',
 				'US SSN',
-				'US EIN'
+				'US EIN',
+				'HR OIB',
+				'HR JMBG',
+				'RO CNP'
 			]
 		},
 		{
 			label: 'Financial',
-			items: ['HR IBAN', 'IE IBAN', 'RO IBAN', 'GB IBAN', 'EU IBANs', 'Credit cards']
+			items: [ 'EU IBANs', 'IE IBAN', 'GB IBAN',  'HR IBAN', 'RO IBAN', 'Credit cards']
 		},
 		{
 			label: 'Contact & Location',
-			items: ['Email addresses', 'Phone numbers', 'Locations']
+			items: ['Email addresses', 'Phone numbers', 'IP addresses', 'Postal address']
+		},
+		{
+			label: 'Secrets',
+			items: ['Passwords', 'API keys', 'Tokens']
 		}
 	];
 


### PR DESCRIPTION
## Summary

Improves the PII masking UX in two places: the message input toggle and the Privacy & PII settings.

## Changes

- **Message input** — flipped the PII masking toggle's orientation (`scale-x-[-1]`), and it now cross-fades between its on/off icons (absolutely-positioned icons with `opacity` + `transition`) instead of swapping via `{#if}`, giving a smooth animated state change.


<img width="775" height="130" alt="image" src="https://github.com/user-attachments/assets/0b54935b-feeb-47ec-ba1b-6209afd216ec" />

- **Privacy & PII settings** — expanded the "Detected data types" badges to reflect the pipeline's current coverage:
  - Added `Usernames` to **Identity**
  - Added `IP addresses` and replaced `Locations` with `Postal address` in **Contact & Location**
  - Added a new **Secrets** group (`Passwords`, `API keys`, `Tokens`)
  - Reordered Identity and Financial entries for readability

<img width="1344" height="730" alt="image" src="https://github.com/user-attachments/assets/297322b7-a0d6-418a-b497-ee508e18fe7f" />
