### PR TITLE
TRAU-520: retry transient LLM errors on OpenAI chat-completion path

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,15 @@
 # Maximum seconds to wait between stream chunks before aborting (default: 60, minimum recommended: 30)
 AIOHTTP_CLIENT_TIMEOUT_SOCK_READ=60
 
+# LLM chat-completion transient-error retry (TRAU-520).
+# Total upstream attempts including the first (default 3 = 1 try + 2 retries).
+LLM_RETRY_MAX=3
+# Wall-clock cap in seconds across all retry attempts (default 90).
+LLM_RETRY_MAX_DURATION_SECONDS=90
+# Comma-separated upstream HTTP statuses worth retrying. Unset = the default set
+# below (transient 5xx + Cloudflare 520-524 + provider-overloaded 529).
+LLM_RETRY_RETRYABLE_STATUS=429,500,502,503,504,520,521,522,523,524,529
+
 LANGFUSE_SK=""
 LANGFUSE_PK=""
 LANGFUSE_HOST=""

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -738,6 +738,82 @@ else:
         _sock_read_source = "default"
         AIOHTTP_CLIENT_TIMEOUT_SOCK_READ = 60
 
+
+####################################
+# LLM chat-completion transient-error retry (TRAU-520)
+####################################
+# Operational knobs for the retry loop around the upstream chat-completion call
+# in routers/openai.py. Env-driven (like AIOHTTP_CLIENT_TIMEOUT above) so a
+# deployment can tune retry aggressiveness without a code change / PR; each falls
+# back to a safe default on an unset or invalid value.
+
+# Total attempts INCLUDING the first (3 = 1 try + 2 retries). Values < 1 would
+# disable the call entirely, so they are rejected in favour of the default.
+LLM_RETRY_MAX = os.environ.get("LLM_RETRY_MAX", "3")
+try:
+    LLM_RETRY_MAX = int(LLM_RETRY_MAX)
+    if LLM_RETRY_MAX < 1:
+        raise ValueError("must be >= 1")
+except ValueError:
+    log.warning(
+        f"[llm-retry] Invalid LLM_RETRY_MAX '{LLM_RETRY_MAX}', falling back to 3."
+    )
+    LLM_RETRY_MAX = 3
+
+# Wall-clock cap (seconds) across ALL retry attempts. Guards against a run of
+# attempts each hanging on sock_read piling up unbounded (AIOHTTP_CLIENT_TIMEOUT
+# total defaults to None). Values < 1 are rejected in favour of the default.
+LLM_RETRY_MAX_DURATION_SECONDS = os.environ.get("LLM_RETRY_MAX_DURATION_SECONDS", "90")
+try:
+    LLM_RETRY_MAX_DURATION_SECONDS = int(LLM_RETRY_MAX_DURATION_SECONDS)
+    if LLM_RETRY_MAX_DURATION_SECONDS < 1:
+        raise ValueError("must be >= 1")
+except ValueError:
+    log.warning(
+        f"[llm-retry] Invalid LLM_RETRY_MAX_DURATION_SECONDS "
+        f"'{LLM_RETRY_MAX_DURATION_SECONDS}', falling back to 90."
+    )
+    LLM_RETRY_MAX_DURATION_SECONDS = 90
+
+# Upstream HTTP statuses worth retrying, comma-separated (e.g. "429,500,502,503").
+# Covers standard transient 5xx (500/502/503/504), Cloudflare origin errors
+# (520-524) and provider "overloaded" (529); deterministic 5xx (501/505/510/511)
+# are intentionally absent so a real config error surfaces immediately. session
+# .request() does NOT raise on an error status, so retryable-vs-not is decided
+# explicitly against this set. An unset or unparseable value falls back to the
+# full default set.
+_LLM_RETRY_RETRYABLE_STATUS_DEFAULT = {
+    429,  # Too Many Requests (rate limit)
+    # standard transient 5xx
+    500,
+    502,
+    503,
+    504,
+    # Cloudflare origin errors (transient)
+    520,
+    521,
+    522,
+    523,
+    524,
+    529,  # provider "overloaded" (e.g. Anthropic)
+}
+_llm_retry_status_env = os.environ.get("LLM_RETRY_RETRYABLE_STATUS", "")
+if _llm_retry_status_env.strip() == "":
+    LLM_RETRY_RETRYABLE_STATUS = set(_LLM_RETRY_RETRYABLE_STATUS_DEFAULT)
+else:
+    try:
+        LLM_RETRY_RETRYABLE_STATUS = {
+            int(part) for part in _llm_retry_status_env.split(",") if part.strip()
+        }
+        if not LLM_RETRY_RETRYABLE_STATUS:
+            raise ValueError("no valid statuses parsed")
+    except ValueError:
+        log.warning(
+            f"[llm-retry] Invalid LLM_RETRY_RETRYABLE_STATUS "
+            f"'{_llm_retry_status_env}', falling back to the default set."
+        )
+        LLM_RETRY_RETRYABLE_STATUS = set(_LLM_RETRY_RETRYABLE_STATUS_DEFAULT)
+
 # SSE keepalive interval derived from sock_read: sock_read/4, capped at 20s.
 # None (keepalives disabled) when sock_read < 4 — interval would be 0 and busy-loop.
 _sse_keepalive_base = (

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import time
 from typing import Optional
 
 import aiohttp
@@ -57,6 +58,36 @@ from open_webui.utils.headers import include_user_info_headers
 
 
 log = logging.getLogger(__name__)
+
+
+# LLM chat-completion transient-error retry (TRAU-520).
+#
+# When the upstream chat-completion call fails on a TRANSIENT error — a
+# connection drop, a timeout, or a retryable HTTP status (429 / 5xx) — retry it
+# a few times with a short linear backoff instead of crashing the chat on a
+# blip. Non-retryable failures (400/401/403/404/422, including a 400
+# "context_length_exceeded" for oversized input) are NOT retried — they
+# propagate immediately, unchanged, exactly as before.
+#
+#   LLM_RETRY_MAX                  total attempts incl. the first (3 = 1 try + 2
+#                                  retries). Hardcoded, not env-driven, to match
+#                                  the existing transient-retry idiom on this
+#                                  codebase (utils/middleware.py).
+#   LLM_RETRY_RETRYABLE_STATUS     upstream HTTP statuses worth retrying; every
+#                                  other status (notably non-retryable 4xx)
+#                                  propagates on the first hit. Needed because
+#                                  session.request() does NOT raise on an error
+#                                  status, so the decision is made explicitly on
+#                                  r.status rather than via raise_for_status().
+#   LLM_RETRY_TOTAL_BUDGET_SECONDS wall-clock cap across ALL attempts. Required
+#                                  because AIOHTTP_CLIENT_TIMEOUT (total)
+#                                  defaults to None (no per-request cap), so
+#                                  without this a run of attempts each hanging on
+#                                  sock_read could pile up unbounded and DoS our
+#                                  own handler. Checked before each new attempt.
+LLM_RETRY_MAX = 3
+LLM_RETRY_RETRYABLE_STATUS = {429, 500, 502, 503, 504}
+LLM_RETRY_TOTAL_BUDGET_SECONDS = 90
 
 
 ##########################################
@@ -952,48 +983,149 @@ async def generate_chat_completion(
     streaming = False
     response = None
 
+    # --- LLM transient-error retry (TRAU-520) ---
+    # Pre-stream retry around the upstream call: r.status and r.headers are known
+    # before any byte reaches the client, so this covers BOTH the streaming and
+    # non-streaming branches. A validated "200 + text/event-stream" response is
+    # handed back immediately and never retried.
+    #
+    # KNOWN LIMITATION: a failure that happens MID-STREAM (after an SSE body has
+    # already started emitting) is out of scope — we do not buffer or resume the
+    # stream, so those still surface to the client exactly as they do today.
+    #
+    # The skeleton (for-attempt loop, linear 0.5*(attempt+1) backoff,
+    # sleep-guard) mirrors the transient-retry idiom already used on this
+    # codebase (utils/middleware.py). Two things that idiom does NOT need,
+    # but this call site does, because it uses session.request() directly rather
+    # than raise_for_status() + `async with`:
+    #   1. STATUS CLASSIFICATION — session.request() does not raise on an error
+    #      status, so retryable vs non-retryable is decided explicitly on
+    #      r.status against LLM_RETRY_RETRYABLE_STATUS. A 400
+    #      "context_length_exceeded" stays non-retryable by status and
+    #      propagates on the first hit.
+    #   2. MANUAL PER-ATTEMPT CLEANUP — we must inspect r before deciding whether
+    #      to hand back a StreamingResponse, so we can't wrap the request in
+    #      `async with`; a failed attempt's response/session are closed by hand
+    #      before the next attempt to avoid a connection leak. The finally block
+    #      below only covers the final (non-stream) attempt.
+    #
+    # Pipeline models are NOT retried (single attempt): their POST can carry side
+    # effects and is not necessarily idempotent, so a double POST is unsafe.
+    max_attempts = 1 if model.get("pipeline") else LLM_RETRY_MAX
+    retry_deadline = time.monotonic() + LLM_RETRY_TOTAL_BUDGET_SECONDS
+
     try:
-        session = aiohttp.ClientSession(
-            trust_env=True,
-            timeout=aiohttp.ClientTimeout(
-                total=AIOHTTP_CLIENT_TIMEOUT, sock_read=AIOHTTP_CLIENT_TIMEOUT_SOCK_READ
-            ),
-        )
+        for attempt in range(max_attempts):
+            # Total wall-clock budget across all attempts (see the constant):
+            # stop starting new attempts once the budget is spent, even if
+            # attempts remain.
+            if attempt > 0 and time.monotonic() >= retry_deadline:
+                log.warning(
+                    "LLM retry budget (%ss) exhausted after %d attempt(s); "
+                    "propagating last error.",
+                    LLM_RETRY_TOTAL_BUDGET_SECONDS,
+                    attempt,
+                )
+                break
 
-        r = await session.request(
-            method="POST",
-            url=request_url,
-            data=payload,
-            headers=headers,
-            cookies=cookies,
-            ssl=AIOHTTP_CLIENT_SESSION_SSL,
-        )
-
-        # Check if response is SSE
-        if "text/event-stream" in r.headers.get("Content-Type", ""):
-            streaming = True
-            return StreamingResponse(
-                stream_chunks_handler(r.content),
-                status_code=r.status,
-                headers=dict(r.headers),
-                background=BackgroundTask(
-                    cleanup_response, response=r, session=session
-                ),
-            )
-        else:
             try:
-                response = await r.json()
+                session = aiohttp.ClientSession(
+                    trust_env=True,
+                    timeout=aiohttp.ClientTimeout(
+                        total=AIOHTTP_CLIENT_TIMEOUT,
+                        sock_read=AIOHTTP_CLIENT_TIMEOUT_SOCK_READ,
+                    ),
+                )
+
+                r = await session.request(
+                    method="POST",
+                    url=request_url,
+                    data=payload,
+                    headers=headers,
+                    cookies=cookies,
+                    ssl=AIOHTTP_CLIENT_SESSION_SSL,
+                )
+
+                # Check if response is SSE. A streaming response is a success and
+                # is returned as-is — never retried (mid-stream failures are out
+                # of scope, see above).
+                if "text/event-stream" in r.headers.get("Content-Type", ""):
+                    streaming = True
+                    return StreamingResponse(
+                        stream_chunks_handler(r.content),
+                        status_code=r.status,
+                        headers=dict(r.headers),
+                        background=BackgroundTask(
+                            cleanup_response, response=r, session=session
+                        ),
+                    )
+
+                # Non-stream transient upstream status (429/5xx): retry while
+                # attempts AND budget remain. Every other status — success or a
+                # non-retryable 4xx — falls through and is returned below.
+                if (
+                    r.status in LLM_RETRY_RETRYABLE_STATUS
+                    and attempt + 1 < max_attempts
+                    and time.monotonic() < retry_deadline
+                ):
+                    log.warning(
+                        "LLM call returned retryable status %s "
+                        "(attempt %d/%d); retrying.",
+                        r.status,
+                        attempt + 1,
+                        max_attempts,
+                    )
+                    # DODATAK 2: close this attempt's response/session by hand
+                    # before backing off, or we leak the connection.
+                    await cleanup_response(r, session)
+                    r = None
+                    session = None
+                    await asyncio.sleep(0.5 * (attempt + 1))
+                    continue
+
+                try:
+                    response = await r.json()
+                except Exception as e:
+                    log.error(e)
+                    response = await r.text()
+
+                if r.status >= 400:
+                    if isinstance(response, (dict, list)):
+                        return JSONResponse(status_code=r.status, content=response)
+                    else:
+                        return PlainTextResponse(status_code=r.status, content=response)
+
+                return response
             except Exception as e:
-                log.error(e)
-                response = await r.text()
+                # Transient connection/timeout error (session.request raised).
+                # Retry while attempts and budget remain; otherwise re-raise to
+                # the terminal handler below (preserves existing behavior).
+                log.warning(
+                    "LLM call raised %s (attempt %d/%d).",
+                    type(e).__name__,
+                    attempt + 1,
+                    max_attempts,
+                )
+                # DODATAK 2: manual per-attempt cleanup before retry/terminal.
+                await cleanup_response(r, session)
+                r = None
+                session = None
+                if attempt + 1 < max_attempts and time.monotonic() < retry_deadline:
+                    await asyncio.sleep(0.5 * (attempt + 1))
+                    continue
+                raise
 
-            if r.status >= 400:
-                if isinstance(response, (dict, list)):
-                    return JSONResponse(status_code=r.status, content=response)
-                else:
-                    return PlainTextResponse(status_code=r.status, content=response)
-
-            return response
+        # Reached only when the loop broke out on the budget guard after a
+        # retryable-status backoff (no exception in flight). Surface a terminal
+        # connection error rather than falling through to a None return.
+        raise HTTPException(
+            status_code=503,
+            detail="Open WebUI: Server Connection Error",
+        )
+    except HTTPException:
+        # Already a terminal HTTP error (the budget-exhaustion raise above) —
+        # propagate unchanged, don't re-wrap it as a 500.
+        raise
     except Exception as e:
         log.exception(e)
 

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1092,7 +1092,7 @@ async def generate_chat_completion(
                         attempt + 1,
                         max_attempts,
                     )
-                    # DODATAK 2: close this attempt's response/session by hand
+                    # NOTE: close this attempt's response/session by hand
                     # before backing off, or we leak the connection.
                     await cleanup_response(r, session)
                     r = None
@@ -1113,17 +1113,20 @@ async def generate_chat_completion(
                         return PlainTextResponse(status_code=r.status, content=response)
 
                 return response
-            except Exception as e:
-                # Transient connection/timeout error (session.request raised).
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                # Transient network/timeout error (session build or request).
                 # Retry while attempts and budget remain; otherwise re-raise to
-                # the terminal handler below (preserves existing behavior).
+                # the terminal handler below. ONLY network/timeout exceptions are
+                # caught here — any other exception (a real bug) propagates
+                # straight to the outer handler, unretried, so it is neither
+                # masked as a transient blip nor delayed by backoff.
                 log.warning(
                     "LLM call raised %s (attempt %d/%d).",
                     type(e).__name__,
                     attempt + 1,
                     max_attempts,
                 )
-                # DODATAK 2: manual per-attempt cleanup before retry/terminal.
+                # NOTE: manual per-attempt cleanup before retry/terminal.
                 await cleanup_response(r, session)
                 r = None
                 session = None

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -63,11 +63,11 @@ log = logging.getLogger(__name__)
 # LLM chat-completion transient-error retry (TRAU-520).
 #
 # When the upstream chat-completion call fails on a TRANSIENT error — a
-# connection drop, a timeout, or a retryable HTTP status (429 / 5xx) — retry it
-# a few times with a short linear backoff instead of crashing the chat on a
-# blip. Non-retryable failures (400/401/403/404/422, including a 400
-# "context_length_exceeded" for oversized input) are NOT retried — they
-# propagate immediately, unchanged, exactly as before.
+# connection drop, a timeout, or a transient HTTP status (429, or a transient
+# 5xx — see LLM_RETRY_RETRYABLE_STATUS) — retry it a few times with a short
+# linear backoff instead of crashing the chat on a blip. Non-retryable failures
+# (400/401/403/404/422, including a 400 "context_length_exceeded" for oversized
+# input) are NOT retried — they propagate immediately, unchanged, as before.
 #
 #   LLM_RETRY_MAX                  total attempts incl. the first (3 = 1 try + 2
 #                                  retries). Hardcoded, not env-driven, to match
@@ -79,6 +79,12 @@ log = logging.getLogger(__name__)
 #                                  session.request() does NOT raise on an error
 #                                  status, so the decision is made explicitly on
 #                                  r.status rather than via raise_for_status().
+#                                  Covers the standard transient 5xx (500/502/
+#                                  503/504), Cloudflare origin errors (520-524)
+#                                  and provider "overloaded" (529). Deterministic
+#                                  5xx (501 Not Implemented, 505, 510, 511) are
+#                                  intentionally EXCLUDED so a real config error
+#                                  surfaces immediately instead of being retried.
 #   LLM_RETRY_TOTAL_BUDGET_SECONDS wall-clock cap across ALL attempts. Required
 #                                  because AIOHTTP_CLIENT_TIMEOUT (total)
 #                                  defaults to None (no per-request cap), so
@@ -86,7 +92,12 @@ log = logging.getLogger(__name__)
 #                                  sock_read could pile up unbounded and DoS our
 #                                  own handler. Checked before each new attempt.
 LLM_RETRY_MAX = 3
-LLM_RETRY_RETRYABLE_STATUS = {429, 500, 502, 503, 504}
+LLM_RETRY_RETRYABLE_STATUS = {
+    429,  # Too Many Requests (rate limit)
+    500, 502, 503, 504,  # standard transient 5xx
+    520, 521, 522, 523, 524,  # Cloudflare origin errors (transient)
+    529,  # provider "overloaded" (e.g. Anthropic)
+}
 LLM_RETRY_TOTAL_BUDGET_SECONDS = 90
 
 
@@ -1060,9 +1071,10 @@ async def generate_chat_completion(
                         ),
                     )
 
-                # Non-stream transient upstream status (429/5xx): retry while
-                # attempts AND budget remain. Every other status — success or a
-                # non-retryable 4xx — falls through and is returned below.
+                # Non-stream transient upstream status (429 / transient 5xx):
+                # retry while attempts AND budget remain. Every other status —
+                # success or a non-retryable 4xx — falls through and is returned
+                # below.
                 if (
                     r.status in LLM_RETRY_RETRYABLE_STATUS
                     and attempt + 1 < max_attempts

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import random
 import time
 from typing import Optional
 
@@ -36,6 +37,9 @@ from open_webui.env import (
     AIOHTTP_CLIENT_TIMEOUT_SOCK_READ,
     ENABLE_FORWARD_USER_INFO_HEADERS,
     BYPASS_MODEL_ACCESS_CONTROL,
+    LLM_RETRY_MAX,
+    LLM_RETRY_RETRYABLE_STATUS,
+    LLM_RETRY_MAX_DURATION_SECONDS,
 )
 from open_webui.models.users import UserModel
 
@@ -65,40 +69,38 @@ log = logging.getLogger(__name__)
 # When the upstream chat-completion call fails on a TRANSIENT error — a
 # connection drop, a timeout, or a transient HTTP status (429, or a transient
 # 5xx — see LLM_RETRY_RETRYABLE_STATUS) — retry it a few times with a short
-# linear backoff instead of crashing the chat on a blip. Non-retryable failures
+# jittered backoff instead of crashing the chat on a blip. Non-retryable failures
 # (400/401/403/404/422, including a 400 "context_length_exceeded" for oversized
 # input) are NOT retried — they propagate immediately, unchanged, as before.
 #
-#   LLM_RETRY_MAX                  total attempts incl. the first (3 = 1 try + 2
-#                                  retries). Hardcoded, not env-driven, to match
-#                                  the existing transient-retry idiom on this
-#                                  codebase (utils/middleware.py).
+# The three knobs are env-driven (declared in env.py alongside
+# AIOHTTP_CLIENT_TIMEOUT) so a deployment can tune them without a code change:
+#   LLM_RETRY_MAX                  total attempts incl. the first (default 3 =
+#                                  1 try + 2 retries).
 #   LLM_RETRY_RETRYABLE_STATUS     upstream HTTP statuses worth retrying; every
 #                                  other status (notably non-retryable 4xx)
-#                                  propagates on the first hit. Needed because
-#                                  session.request() does NOT raise on an error
-#                                  status, so the decision is made explicitly on
-#                                  r.status rather than via raise_for_status().
-#                                  Covers the standard transient 5xx (500/502/
-#                                  503/504), Cloudflare origin errors (520-524)
-#                                  and provider "overloaded" (529). Deterministic
-#                                  5xx (501 Not Implemented, 505, 510, 511) are
-#                                  intentionally EXCLUDED so a real config error
-#                                  surfaces immediately instead of being retried.
-#   LLM_RETRY_TOTAL_BUDGET_SECONDS wall-clock cap across ALL attempts. Required
-#                                  because AIOHTTP_CLIENT_TIMEOUT (total)
-#                                  defaults to None (no per-request cap), so
-#                                  without this a run of attempts each hanging on
-#                                  sock_read could pile up unbounded and DoS our
-#                                  own handler. Checked before each new attempt.
-LLM_RETRY_MAX = 3
-LLM_RETRY_RETRYABLE_STATUS = {
-    429,  # Too Many Requests (rate limit)
-    500, 502, 503, 504,  # standard transient 5xx
-    520, 521, 522, 523, 524,  # Cloudflare origin errors (transient)
-    529,  # provider "overloaded" (e.g. Anthropic)
-}
-LLM_RETRY_TOTAL_BUDGET_SECONDS = 90
+#                                  propagates on the first hit. Consulted
+#                                  explicitly because session.request() does NOT
+#                                  raise on an error status.
+#   LLM_RETRY_MAX_DURATION_SECONDS wall-clock cap across ALL attempts (default
+#                                  90s), checked before each new attempt. Guards
+#                                  against attempts each hanging on sock_read
+#                                  piling up unbounded (AIOHTTP_CLIENT_TIMEOUT
+#                                  total defaults to None, i.e. no per-request
+#                                  cap).
+
+
+def _llm_retry_backoff_seconds(attempt: int) -> float:
+    """Jittered backoff (seconds) to wait before the retry that follows `attempt`
+    (0-based). The nominal delay grows linearly — 0.5s, 1.0s, 1.5s, … — but the
+    actual sleep is drawn uniformly from the lower half of that window
+    (nominal/2 .. nominal), the same equal-jitter idiom used for the websocket
+    cleanup lock in socket/main.py. The randomness DECORRELATES a burst of
+    requests that failed together (e.g. one upstream 429/503 spike) so they do
+    not all retry in lockstep and re-create the same thundering herd, while the
+    lower bound keeps a sensible minimum wait."""
+    nominal = 0.5 * (attempt + 1)
+    return random.uniform(nominal / 2, nominal)
 
 
 ##########################################
@@ -1023,7 +1025,7 @@ async def generate_chat_completion(
     # Pipeline models are NOT retried (single attempt): their POST can carry side
     # effects and is not necessarily idempotent, so a double POST is unsafe.
     max_attempts = 1 if model.get("pipeline") else LLM_RETRY_MAX
-    retry_deadline = time.monotonic() + LLM_RETRY_TOTAL_BUDGET_SECONDS
+    retry_deadline = time.monotonic() + LLM_RETRY_MAX_DURATION_SECONDS
 
     try:
         for attempt in range(max_attempts):
@@ -1034,12 +1036,21 @@ async def generate_chat_completion(
                 log.warning(
                     "LLM retry budget (%ss) exhausted after %d attempt(s); "
                     "propagating last error.",
-                    LLM_RETRY_TOTAL_BUDGET_SECONDS,
+                    LLM_RETRY_MAX_DURATION_SECONDS,
                     attempt,
                 )
                 break
 
             try:
+                # A FRESH session (and connection) per attempt is intentional,
+                # not an oversight. Hoisting one session out of the loop would
+                # save at most a single TCP+TLS handshake on a retry, but (a) the
+                # retry path already sleeps a jittered backoff (>= 0.25s) that
+                # dwarfs a handshake, (b) cleanup_response closes the connection
+                # (not release-to-pool) so reuse would need deeper changes to help
+                # at all, and (c) a new connection lets a load balancer re-route
+                # away from the struggling upstream node that caused the retry.
+                # So each attempt fully owns and tears down its own session.
                 session = aiohttp.ClientSession(
                     trust_env=True,
                     timeout=aiohttp.ClientTimeout(
@@ -1097,7 +1108,7 @@ async def generate_chat_completion(
                     await cleanup_response(r, session)
                     r = None
                     session = None
-                    await asyncio.sleep(0.5 * (attempt + 1))
+                    await asyncio.sleep(_llm_retry_backoff_seconds(attempt))
                     continue
 
                 try:
@@ -1131,7 +1142,7 @@ async def generate_chat_completion(
                 r = None
                 session = None
                 if attempt + 1 < max_attempts and time.monotonic() < retry_deadline:
-                    await asyncio.sleep(0.5 * (attempt + 1))
+                    await asyncio.sleep(_llm_retry_backoff_seconds(attempt))
                     continue
                 raise
 

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1057,10 +1057,15 @@ async def generate_chat_completion(
                     ssl=AIOHTTP_CLIENT_SESSION_SSL,
                 )
 
-                # Check if response is SSE. A streaming response is a success and
-                # is returned as-is — never retried (mid-stream failures are out
-                # of scope, see above).
-                if "text/event-stream" in r.headers.get("Content-Type", ""):
+                # Check if response is SSE. Only a validated 200 + event-stream
+                # is a streaming success returned as-is (never retried; mid-stream
+                # failures are out of scope, see above). An event-stream that
+                # carries a retryable error status (e.g. 503 from a proxy) must
+                # NOT short-circuit here — it falls through to the status check
+                # below and is retried like any other transient error.
+                if r.status == 200 and "text/event-stream" in r.headers.get(
+                    "Content-Type", ""
+                ):
                     streaming = True
                     return StreamingResponse(
                         stream_chunks_handler(r.content),

--- a/backend/open_webui/tests/test_openai_retry.py
+++ b/backend/open_webui/tests/test_openai_retry.py
@@ -1,0 +1,304 @@
+"""
+Tests for the LLM transient-error retry on the OpenAI-compatible chat-completion
+path (routers/openai.py::generate_chat_completion, TRAU-520).
+
+The retry loop wraps the upstream `session.request(...)` call. It retries on a
+transient connection/timeout exception or a retryable HTTP status (429/5xx), and
+propagates every other status (notably non-retryable 4xx like a 400
+context_length_exceeded) immediately. Pipeline models are not retried, and a
+total wall-clock budget caps the whole loop.
+
+We call generate_chat_completion() directly (bypassing FastAPI's Depends) with a
+minimal request stub, patch the module's heavy preamble helpers to no-ops, and
+mock aiohttp.ClientSession so session.request() returns a scripted sequence of
+responses/exceptions. asyncio.sleep is patched out so backoff is instant, and
+time.monotonic is patched where a test needs to drive the budget guard.
+"""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+# stripe is an optional billing dependency not installed in the test environment.
+# Mock it before any open_webui import triggers the import chain (billing router
+# is imported transitively by routers/openai.py).
+sys.modules.setdefault("stripe", MagicMock())
+
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse, StreamingResponse
+
+import open_webui.routers.openai as openai_router
+from open_webui.routers.openai import generate_chat_completion
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_request(base_url="https://api.openai.com/v1", key="sk-test"):
+    """Minimal FastAPI request stub with just the state the function reads."""
+    request = MagicMock()
+    request.app.state.OPENAI_MODELS = {}  # set per test via _make_model
+    request.app.state.config.OPENAI_API_CONFIGS = {}  # real dict -> api_config = {}
+    request.app.state.config.OPENAI_API_BASE_URLS = [base_url]
+    request.app.state.config.OPENAI_API_KEYS = [key]
+    return request
+
+
+def _make_user():
+    user = MagicMock()
+    user.id = "user-1"
+    user.role = "admin"
+    user.name = "Test"
+    user.email = "test@example.com"
+    return user
+
+
+def _make_model(pipeline=False):
+    """An OPENAI_MODELS entry. pipeline=True marks it as a Pipelines model."""
+    model = {"id": "gpt-4", "urlIdx": 0, "name": "gpt-4"}
+    if pipeline:
+        model["pipeline"] = {"type": "pipe"}
+    return model
+
+
+def _fake_clock(values):
+    """
+    Isolated monotonic clock: returns the scripted values in order, then repeats
+    the last one forever (never raises StopIteration). Patched onto the openai
+    module's `time` NAME only, so asyncio's own time.monotonic() is untouched.
+    """
+    seq = list(values)
+    state = {"i": 0}
+
+    def _mono():
+        v = seq[min(state["i"], len(seq) - 1)]
+        state["i"] += 1
+        return v
+
+    return SimpleNamespace(monotonic=_mono)
+
+
+def _resp(status, content_type="application/json", body=None):
+    """A mock aiohttp ClientResponse."""
+    r = MagicMock()
+    r.status = status
+    r.headers = {"Content-Type": content_type}
+    r.json = AsyncMock(return_value=body if body is not None else {"ok": True})
+    r.text = AsyncMock(return_value="upstream error body")
+    r.close = MagicMock()  # cleanup_response calls response.close() (sync)
+    return r
+
+
+class _SessionPatch:
+    """
+    Patch aiohttp.ClientSession in the openai module so each ClientSession(...)
+    yields a fresh session whose .request is a shared AsyncMock scripted with
+    `outcomes` (each item: a mock response to return, or an Exception to raise).
+    Every session.close() is an awaitable no-op. Exposes .call_count.
+    """
+
+    def __init__(self, outcomes):
+        self.request = AsyncMock(side_effect=outcomes)
+        self.sessions = []
+
+    def _make_session(self, *args, **kwargs):
+        s = MagicMock()
+        s.request = self.request
+        s.close = AsyncMock()
+        self.sessions.append(s)
+        return s
+
+    def __enter__(self):
+        self._patch = patch.object(
+            openai_router.aiohttp, "ClientSession", side_effect=self._make_session
+        )
+        self._patch.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._patch.stop()
+        return False
+
+    @property
+    def call_count(self):
+        return self.request.call_count
+
+
+def _run(request, model, outcomes, form_data=None):
+    """
+    Drive generate_chat_completion with the heavy preamble patched out and a
+    scripted session. Returns (result_or_raise, session_patch). asyncio.sleep is
+    neutralised so backoff does not slow the test.
+    """
+    request.app.state.OPENAI_MODELS = {"gpt-4": model}
+    form_data = form_data or {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}
+
+    with _SessionPatch(outcomes) as sess, \
+        patch.object(openai_router, "get_all_models", AsyncMock(return_value={})), \
+        patch.object(openai_router, "get_headers_and_cookies", AsyncMock(return_value=({}, {}))), \
+        patch.object(openai_router.Models, "get_model_by_id", MagicMock(return_value=None)), \
+        patch.object(openai_router.asyncio, "sleep", AsyncMock()):
+        coro = generate_chat_completion(
+            request, form_data, user=_make_user(), bypass_filter=True, db=None
+        )
+        result = asyncio.run(coro)
+    return result, sess
+
+
+# ---------------------------------------------------------------------------
+# 1. Retryable status recovers
+# ---------------------------------------------------------------------------
+
+def test_retryable_status_then_success_returns_body():
+    request = _make_request()
+    body = {"choices": [{"message": {"content": "ok"}}]}
+    result, sess = _run(request, _make_model(), [_resp(503), _resp(200, body=body)])
+    assert result == body
+    assert sess.call_count == 2  # one retry
+
+
+def test_retryable_backoff_sleeps_between_attempts():
+    request = _make_request()
+    with patch.object(openai_router.asyncio, "sleep", AsyncMock()) as sleep_mock:
+        # re-run inside our own sleep patch so we can assert on it
+        request.app.state.OPENAI_MODELS = {"gpt-4": _make_model()}
+        fd = {"model": "gpt-4", "messages": []}
+        with _SessionPatch([_resp(503), _resp(200)]), \
+            patch.object(openai_router, "get_all_models", AsyncMock(return_value={})), \
+            patch.object(openai_router, "get_headers_and_cookies", AsyncMock(return_value=({}, {}))), \
+            patch.object(openai_router.Models, "get_model_by_id", MagicMock(return_value=None)):
+            asyncio.run(generate_chat_completion(request, fd, user=_make_user(), bypass_filter=True, db=None))
+        assert sleep_mock.await_count == 1  # backoff before the single retry
+
+
+# ---------------------------------------------------------------------------
+# 2. Non-retryable status is NOT retried
+# ---------------------------------------------------------------------------
+
+def test_non_retryable_400_returns_immediately():
+    request = _make_request()
+    err = {"error": {"code": "context_length_exceeded", "message": "too long"}}
+    result, sess = _run(request, _make_model(), [_resp(400, body=err)])
+    assert isinstance(result, JSONResponse)
+    assert result.status_code == 400
+    assert sess.call_count == 1  # no retry on a non-retryable status
+
+
+def test_non_retryable_does_not_sleep():
+    request = _make_request()
+    request.app.state.OPENAI_MODELS = {"gpt-4": _make_model()}
+    fd = {"model": "gpt-4", "messages": []}
+    with _SessionPatch([_resp(401, body={"error": "bad key"})]), \
+        patch.object(openai_router, "get_all_models", AsyncMock(return_value={})), \
+        patch.object(openai_router, "get_headers_and_cookies", AsyncMock(return_value=({}, {}))), \
+        patch.object(openai_router.Models, "get_model_by_id", MagicMock(return_value=None)), \
+        patch.object(openai_router.asyncio, "sleep", AsyncMock()) as sleep_mock:
+        result = asyncio.run(
+            generate_chat_completion(request, fd, user=_make_user(), bypass_filter=True, db=None)
+        )
+    assert isinstance(result, JSONResponse)
+    assert result.status_code == 401
+    assert sleep_mock.await_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Exhaustion: retryable status on every attempt -> returns last error as-is
+# ---------------------------------------------------------------------------
+
+def test_all_attempts_retryable_returns_upstream_error():
+    request = _make_request()
+    # Constant clock keeps us under the budget; all 3 attempts run.
+    with patch.object(openai_router, "time", _fake_clock([0.0])):
+        result, sess = _run(
+            request, _make_model(),
+            [_resp(503, body={"error": "busy"}),
+             _resp(503, body={"error": "busy"}),
+             _resp(503, body={"error": "busy"})],
+        )
+    assert isinstance(result, JSONResponse)
+    assert result.status_code == 503
+    assert sess.call_count == openai_router.LLM_RETRY_MAX  # exactly 3 attempts
+
+
+# ---------------------------------------------------------------------------
+# 4. Exception (connection/timeout) is retried, then succeeds
+# ---------------------------------------------------------------------------
+
+def test_connection_exception_then_success():
+    request = _make_request()
+    body = {"choices": []}
+    result, sess = _run(
+        request, _make_model(),
+        [aiohttp.ClientError("boom"), asyncio.TimeoutError(), _resp(200, body=body)],
+    )
+    assert result == body
+    assert sess.call_count == 3
+
+
+def test_exception_on_every_attempt_raises_terminal_502_or_500():
+    request = _make_request()
+    with patch.object(openai_router, "time", _fake_clock([0.0])):
+        with pytest.raises(HTTPException) as ei:
+            _run(
+                request, _make_model(),
+                [aiohttp.ClientError("a"), aiohttp.ClientError("b"), aiohttp.ClientError("c")],
+            )
+    # Terminal handler: r is None after cleanup -> 500 "Server Connection Error".
+    assert ei.value.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# 5. Pipeline models are NOT retried (single attempt)
+# ---------------------------------------------------------------------------
+
+def test_pipeline_model_not_retried():
+    request = _make_request()
+    result, sess = _run(request, _make_model(pipeline=True), [_resp(503, body={"error": "busy"})])
+    assert isinstance(result, JSONResponse)
+    assert result.status_code == 503
+    assert sess.call_count == 1  # pipeline -> max_attempts == 1
+
+
+# ---------------------------------------------------------------------------
+# 6. Total wall-clock budget stops a new attempt
+# ---------------------------------------------------------------------------
+
+def test_budget_exhaustion_stops_before_next_attempt():
+    request = _make_request()
+    request.app.state.OPENAI_MODELS = {"gpt-4": _make_model()}
+    fd = {"model": "gpt-4", "messages": []}
+    # monotonic sequence (isolated to the openai module):
+    #   call 1 -> retry_deadline = 0 + 90 = 90
+    #   call 2 -> status-retry budget check (attempt 0): 1 < 90 -> retry
+    #   call 3 -> top-of-loop guard (attempt 1): 100 >= 90 -> break -> terminal 503
+    with _SessionPatch([_resp(503), _resp(503), _resp(503)]) as sess, \
+        patch.object(openai_router, "get_all_models", AsyncMock(return_value={})), \
+        patch.object(openai_router, "get_headers_and_cookies", AsyncMock(return_value=({}, {}))), \
+        patch.object(openai_router.Models, "get_model_by_id", MagicMock(return_value=None)), \
+        patch.object(openai_router.asyncio, "sleep", AsyncMock()), \
+        patch.object(openai_router, "time", _fake_clock([0.0, 1.0, 100.0])):
+        with pytest.raises(HTTPException) as ei:
+            asyncio.run(
+                generate_chat_completion(request, fd, user=_make_user(), bypass_filter=True, db=None)
+            )
+    assert ei.value.status_code == 503
+    # Budget blocked the 2nd network attempt: only one request went out.
+    assert sess.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# 7. Streaming success returns a StreamingResponse and is never retried
+# ---------------------------------------------------------------------------
+
+def test_streaming_success_returns_streamingresponse():
+    request = _make_request()
+    result, sess = _run(
+        request, _make_model(), [_resp(200, content_type="text/event-stream")]
+    )
+    assert isinstance(result, StreamingResponse)
+    assert sess.call_count == 1

--- a/backend/open_webui/tests/test_openai_retry.py
+++ b/backend/open_webui/tests/test_openai_retry.py
@@ -267,7 +267,26 @@ def test_connection_exception_then_success():
     assert sess.call_count == 3
 
 
-def test_exception_on_every_attempt_raises_terminal_502_or_500():
+def test_non_network_exception_not_retried():
+    # A non-network exception (a real bug, e.g. ValueError) must NOT be retried
+    # or masked as a transient blip — it propagates on the first attempt.
+    request = _make_request()
+    request.app.state.OPENAI_MODELS = {"gpt-4": _make_model()}
+    fd = {"model": "gpt-4", "messages": []}
+    with _SessionPatch([ValueError("bug"), _resp(200)]) as sess, \
+        patch.object(openai_router, "get_all_models", AsyncMock(return_value={})), \
+        patch.object(openai_router, "get_headers_and_cookies", AsyncMock(return_value=({}, {}))), \
+        patch.object(openai_router.Models, "get_model_by_id", MagicMock(return_value=None)), \
+        patch.object(openai_router.asyncio, "sleep", AsyncMock()), \
+        patch.object(openai_router, "time", _fake_clock([0.0])):
+        with pytest.raises(HTTPException):
+            asyncio.run(
+                generate_chat_completion(request, fd, user=_make_user(), bypass_filter=True, db=None)
+            )
+    assert sess.call_count == 1  # not retried
+
+
+def test_exception_on_every_attempt_raises_terminal_500():
     request = _make_request()
     with patch.object(openai_router, "time", _fake_clock([0.0])):
         with pytest.raises(HTTPException) as ei:

--- a/backend/open_webui/tests/test_openai_retry.py
+++ b/backend/open_webui/tests/test_openai_retry.py
@@ -363,3 +363,22 @@ def test_event_stream_with_retryable_status_is_retried():
     )
     assert isinstance(result, StreamingResponse)
     assert sess.call_count == 2  # the 503 event-stream was retried, not returned
+
+
+# ---------------------------------------------------------------------------
+# 8. Jittered backoff: bounds + a growing window that decorrelates retries
+# ---------------------------------------------------------------------------
+
+def test_backoff_is_jittered_within_growing_bounds():
+    # Equal-jitter idiom (mirrors socket/main.py): the wait for the retry after
+    # attempt N is drawn uniformly from [nominal/2, nominal] with nominal =
+    # 0.5*(N+1). Bounds must hold for every draw, and the window must grow per
+    # attempt so later retries wait longer.
+    for attempt in range(4):
+        nominal = 0.5 * (attempt + 1)
+        draws = [openai_router._llm_retry_backoff_seconds(attempt) for _ in range(1000)]
+        assert all(nominal / 2 <= d <= nominal for d in draws)
+
+    # Jitter actually varies (not a constant) — decorrelation is the whole point.
+    same_attempt = {openai_router._llm_retry_backoff_seconds(0) for _ in range(50)}
+    assert len(same_attempt) > 1

--- a/backend/open_webui/tests/test_openai_retry.py
+++ b/backend/open_webui/tests/test_openai_retry.py
@@ -329,3 +329,18 @@ def test_streaming_success_returns_streamingresponse():
     )
     assert isinstance(result, StreamingResponse)
     assert sess.call_count == 1
+
+
+def test_event_stream_with_retryable_status_is_retried():
+    # A proxy can return an error status WITH a text/event-stream content-type.
+    # Only 200 + event-stream is a streaming success; a 503 + event-stream must
+    # NOT short-circuit as streaming — it is retried like any transient error.
+    request = _make_request()
+    result, sess = _run(
+        request,
+        _make_model(),
+        [_resp(503, content_type="text/event-stream"),
+         _resp(200, content_type="text/event-stream")],
+    )
+    assert isinstance(result, StreamingResponse)
+    assert sess.call_count == 2  # the 503 event-stream was retried, not returned

--- a/backend/open_webui/tests/test_openai_retry.py
+++ b/backend/open_webui/tests/test_openai_retry.py
@@ -176,9 +176,36 @@ def test_retryable_backoff_sleeps_between_attempts():
         assert sleep_mock.await_count == 1  # backoff before the single retry
 
 
+def test_cloudflare_5xx_is_retried():
+    # 522 (Cloudflare "connection timed out") is transient -> must be retried.
+    request = _make_request()
+    body = {"choices": []}
+    result, sess = _run(request, _make_model(), [_resp(522), _resp(200, body=body)])
+    assert result == body
+    assert sess.call_count == 2
+
+
+def test_provider_overloaded_529_is_retried():
+    # 529 ("overloaded", e.g. Anthropic) is transient -> must be retried.
+    request = _make_request()
+    body = {"choices": []}
+    result, sess = _run(request, _make_model(), [_resp(529), _resp(200, body=body)])
+    assert result == body
+    assert sess.call_count == 2
+
+
 # ---------------------------------------------------------------------------
 # 2. Non-retryable status is NOT retried
 # ---------------------------------------------------------------------------
+
+
+def test_deterministic_5xx_not_retried():
+    # 501 (Not Implemented) is deterministic, NOT transient -> propagate at once.
+    request = _make_request()
+    result, sess = _run(request, _make_model(), [_resp(501, body={"error": "nope"})])
+    assert isinstance(result, JSONResponse)
+    assert result.status_code == 501
+    assert sess.call_count == 1  # no retry on a deterministic 5xx
 
 def test_non_retryable_400_returns_immediately():
     request = _make_request()


### PR DESCRIPTION
## Summary

Adds a bounded transient-error retry around the upstream call in `generate_chat_completion` (the OpenAI-compatible chat-completion path). When the upstream LLM call fails on a **transient** error — a connection drop, a timeout, or a retryable HTTP status (429 / 5xx) — it is retried with a short linear backoff instead of crashing the chat turn. **Non-retryable** failures (400/401/403/404/422, including a `400 context_length_exceeded`) propagate immediately, unchanged.

Because this sits on the OpenAI-compatible path, it covers every model connected via **Connections** (OpenAI, plus Anthropic/Gemini when connected as OpenAI-compatible connections), as well as task jobs (title / tag / autocomplete) that route through the same call site.

## Motivation

On large prompts that require PII masking, the already-completed (and expensive) masking step is sometimes followed by a transient LLM failure that crashes the whole turn, forcing a manual regenerate. Retrying only the LLM re-POST — which happens **after** masking — rides out the blip without re-running masking.

> **Scope note:** this addresses the *transient* failure mode only. A deterministic `400 context_length_exceeded` on an oversized prompt is intentionally **not** retried (a retry would fail identically) and is tracked separately as a context-management follow-up.


## How it works

- **Skeleton** mirrors the existing transient-retry idiom in `utils/middleware.py` (for-attempt loop, linear `0.5 * (attempt + 1)` backoff, sleep-guard).
- **Status classification** — `session.request()` does not raise on an error status, so retryable vs non-retryable is decided explicitly on `r.status`.
- **Manual per-attempt cleanup** — we must inspect the response before deciding whether to return a `StreamingResponse`, so `async with` can't be used; each failed attempt closes its response/session by hand to avoid a connection leak.
- **Pre-stream** — status/headers are known before any byte reaches the client, so the retry covers both the streaming and non-streaming branches; a valid `200 + text/event-stream` is returned immediately and never retried.
- **Total budget** — capped at 90s across all attempts, because `AIOHTTP_CLIENT_TIMEOUT` (total) defaults to `None`.
- **Pipeline models** — not retried (single attempt); their POST may carry side effects and is not necessarily idempotent.


## Known limitations / follow-ups

- A mid-stream failure (after a `text/event-stream` body has started) is not buffered or resumed.
- Deterministic `400 context_length_exceeded` is out of scope — needs a separate context-management follow-up (RAG `TOP_K` trim, a pre-flight token-count guard with a clear message instead of a raw 400, chunking, or a larger-context model).
