### PR TITLE
STAGING: fix/TRAU-524

### DIFF
--- a/backend/open_webui/migrations/versions/a1b2c3d4e5f6_add_is_encrypted_to_chat.py
+++ b/backend/open_webui/migrations/versions/a1b2c3d4e5f6_add_is_encrypted_to_chat.py
@@ -10,15 +10,14 @@ column must be TEXT before any encrypted writes can happen.
 
 On PostgreSQL the USING clause casts the existing JSON value to its text
 representation (identical bytes, no data loss). On SQLite the column is
-already stored as TEXT at the storage level; the alter_column call updates
-the type annotation only.
+already stored as TEXT at the storage level, so upgrade()/downgrade() are
+no-ops there.
 
 Encryption status is inferred from the ENC1: prefix — no separate column needed.
 """
 
 from typing import Sequence, Union
 
-import sqlalchemy as sa
 from alembic import op
 
 revision: str = "a1b2c3d4e5f6"
@@ -37,10 +36,10 @@ def upgrade():
         op.execute(
             "ALTER TABLE chat ALTER COLUMN chat TYPE TEXT USING chat::text"
         )
-    else:
-        # SQLite stores everything as TEXT already; update the type annotation
-        # so SQLAlchemy reflects the column correctly going forward.
-        op.alter_column("chat", "chat", existing_type=sa.JSON(), type_=sa.Text())
+    # SQLite stores everything as TEXT at the storage level regardless of the
+    # declared column type, so no DDL is needed here. (A plain op.alter_column
+    # would emit "ALTER TABLE chat ALTER COLUMN chat TYPE TEXT", which is not
+    # valid SQLite syntax and would need op.batch_alter_table instead.)
 
 
 def downgrade():
@@ -53,5 +52,4 @@ def downgrade():
         op.execute(
             "ALTER TABLE chat ALTER COLUMN chat TYPE JSON USING chat::json"
         )
-    else:
-        op.alter_column("chat", "chat", existing_type=sa.Text(), type_=sa.JSON())
+    # SQLite: no DDL was performed in upgrade(), so nothing to revert here.

--- a/backend/open_webui/tests/apps/webui/routers/test_billing_topup.py
+++ b/backend/open_webui/tests/apps/webui/routers/test_billing_topup.py
@@ -120,14 +120,16 @@ class TestCreateTopup:
                 object=SimpleNamespace(
                     id="cs_123",
                     payment_status="paid",
-                    metadata={"type": "topup", "user_id": "u1", "credits": "500"},
+                    metadata={"type": "topup", "user_id": "u1", "top_up_id": "pack_basic"},
                 )
             ),
         )
         with patch("open_webui.routers.billing.stripe.Webhook.construct_event", return_value=event):
-            with patch("open_webui.routers.billing.StripeBillings.get_by_topup_checkout_session_id", return_value=True):
-                r = client.post("/api/v1/billing/webhook", content=b"{}", headers={"stripe-signature": "sig"})
+            with patch("open_webui.models.purchase_history.PurchaseHistory.already_processed", return_value=True):
+                with patch("open_webui.models.credit_balances.CreditBalances.add_topup") as mock_add:
+                    r = client.post("/api/v1/billing/webhook", content=b"{}", headers={"stripe-signature": "sig"})
         assert r.status_code == 200
+        mock_add.assert_not_called()
 
     def test_webhook_topup_skipped_if_not_paid(self):
         event = SimpleNamespace(
@@ -136,12 +138,12 @@ class TestCreateTopup:
                 object=SimpleNamespace(
                     id="cs_123",
                     payment_status="unpaid",
-                    metadata={"type": "topup", "user_id": "u1", "credits": "500"},
+                    metadata={"type": "topup", "user_id": "u1", "top_up_id": "pack_basic"},
                 )
             ),
         )
         with patch("open_webui.routers.billing.stripe.Webhook.construct_event", return_value=event):
-            with patch("open_webui.routers.billing.StripeBillings.add_top_up_credits") as mock_add:
+            with patch("open_webui.models.credit_balances.CreditBalances.add_topup") as mock_add:
                 r = client.post("/api/v1/billing/webhook", content=b"{}", headers={"stripe-signature": "sig"})
         assert r.status_code == 200
         mock_add.assert_not_called()

--- a/backend/open_webui/tests/routers/test_billing.py
+++ b/backend/open_webui/tests/routers/test_billing.py
@@ -100,27 +100,29 @@ class TestCheckCreditsExhausted:
         record.plan_tier = "pro"
         record.created_at = 0
 
-        credits_row = MagicMock()
-        credits_row.balance = 100
-        credits_row.credits_per_eur_cent = 1.82
+        balance = MagicMock()
+        balance.subscription_credits = 100
+        balance.topup_credits = 0
+        balance.credits_per_eur_cent = 1.82
 
         mock_billings = MagicMock()
         mock_billings.get_by_user_id.return_value = record
-        mock_uc_db = MagicMock()
-        mock_uc_db.get.return_value = credits_row
+        mock_balances = MagicMock()
+        mock_balances.get.return_value = balance
 
+        import open_webui.models.credit_balances as cb_mod
+        import open_webui.models.user_credits as uc_mod
         with patch.dict(os.environ, {"CREDITS_PER_EUR_CENT": "1.82"}), \
              patch.object(_billing, "StripeBillings", mock_billings), \
              patch.object(_billing, "CREDITS_TIERS", {"trial", "pro", "premium"}), \
              patch.object(_billing, "PLAN_TIER_TRIAL", "trial"), \
-             patch.object(_billing, "_get_user_current_month_cost", return_value=1.0):
-            import open_webui.models.user_credits as uc_mod
-            with patch.object(uc_mod, "UserCreditsDB", mock_uc_db), \
-                 patch.object(uc_mod, "eur_to_credits", return_value=200):
-                with pytest.raises(HTTPException) as exc_info:
-                    _billing._check_credits_exhausted("user@example.com", "user-uuid-123")
-                assert exc_info.value.status_code == 402
-                assert exc_info.value.detail == "credits_exhausted"
+             patch.object(_billing, "_get_user_current_month_cost", return_value=1.0), \
+             patch.object(cb_mod, "CreditBalances", mock_balances), \
+             patch.object(uc_mod, "eur_to_credits", return_value=200):
+            with pytest.raises(HTTPException) as exc_info:
+                _billing._check_credits_exhausted("user@example.com", "user-uuid-123")
+            assert exc_info.value.status_code == 402
+            assert exc_info.value.detail == "credits_exhausted"
 
 
 # ---------------------------------------------------------------------------
@@ -269,7 +271,7 @@ class TestAutoOnboardUserTierConstants:
         mock_billings.get_by_user_id.return_value = None  # not yet onboarded
         with patch.object(_billing, "StripeBillings", mock_billings), \
              patch.object(_billing, "BILLING_ENABLED", True), \
-             patch.object(_billing, "is_internal_user", return_value=True):
+             patch.object(_billing, "has_unlimited_access", return_value=True):
             user = MagicMock()
             user.email = "staff@keeper.ai"
             user.id = "uid-internal"
@@ -292,7 +294,7 @@ class TestAutoOnboardUserTierConstants:
 
         with patch.object(_billing, "StripeBillings", mock_billings), \
              patch.object(_billing, "BILLING_ENABLED", True), \
-             patch.object(_billing, "is_internal_user", return_value=False), \
+             patch.object(_billing, "has_unlimited_access", return_value=False), \
              patch.object(_billing, "STRIPE_SECRET_KEY", "sk_test"), \
              patch.object(_billing, "STRIPE_FREE_TIER_CENTS", 0), \
              patch.object(_billing, "get_stripe_client", return_value=mock_stripe), \

--- a/backend/open_webui/tests/routers/test_billing.py
+++ b/backend/open_webui/tests/routers/test_billing.py
@@ -110,16 +110,16 @@ class TestCheckCreditsExhausted:
         mock_balances = MagicMock()
         mock_balances.get.return_value = balance
 
-        import open_webui.models.credit_balances as cb_mod
-        import open_webui.models.user_credits as uc_mod
-        with patch.dict(os.environ, {"CREDITS_PER_EUR_CENT": "1.82"}), \
-             patch.object(_billing, "StripeBillings", mock_billings), \
-             patch.object(_billing, "CREDITS_TIERS", {"trial", "pro", "premium"}), \
-             patch.object(_billing, "PLAN_TIER_TRIAL", "trial"), \
-             patch.object(_billing, "_get_user_current_month_cost", return_value=1.0), \
-             patch.object(cb_mod, "CreditBalances", mock_balances), \
-             patch.object(uc_mod, "eur_to_credits", return_value=200):
-            with pytest.raises(HTTPException) as exc_info:
+        with patch.dict(os.environ, {"CREDITS_PER_EUR_CENT": "1.82"}):
+            import open_webui.models.credit_balances as cb_mod
+            import open_webui.models.user_credits as uc_mod
+            with patch.object(_billing, "StripeBillings", mock_billings), \
+                 patch.object(_billing, "CREDITS_TIERS", {"trial", "pro", "premium"}), \
+                 patch.object(_billing, "PLAN_TIER_TRIAL", "trial"), \
+                 patch.object(_billing, "_get_user_current_month_cost", return_value=1.0), \
+                 patch.object(cb_mod, "CreditBalances", mock_balances), \
+                 patch.object(uc_mod, "eur_to_credits", return_value=200), \
+                 pytest.raises(HTTPException) as exc_info:
                 _billing._check_credits_exhausted("user@example.com", "user-uuid-123")
             assert exc_info.value.status_code == 402
             assert exc_info.value.detail == "credits_exhausted"


### PR DESCRIPTION
### Changes
- Refactor failing Stripe tests, 
- Refactor `a1b2c3d4e5f6_add_is_encrypted_to_chat.py` migration for SQLite with invalid syntax that caused failure in local dev test runs